### PR TITLE
docs: add links to WG meeting agendas

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
 ## Upcoming Agendas
 
-- [Community & Safety WG](...)
 - [Docs & Tooling WG](https://hackmd.io/vGzeV75VTE2CMjHQdOYxiA)
 - [Outreach WG](https://hackmd.io/v2xd8N3jSfWB58ZoEs6rag)
 - [Releases WG](https://hackmd.io/UulAOzHORt62Hbbptv3Vig)


### PR DESCRIPTION
As a convenient place to go if you want to add something to a WG's meeting agenda