### PR TITLE
docs: copyedit and organize meeting minutes

### DIFF
--- a/wg-releases/meeting-minutes/2-27-19.md
+++ b/wg-releases/meeting-minutes/2-27-19.md
@@ -1,41 +1,45 @@
 ## Release WG Minutes - 2-27-19
 
 ## Attendees
+
+** WG Members
 * @MarshallOfSound
 * @ckerr
 * @codebytere
 * @jkleinsc
-* @nornagon
 * @sofianguy
 
+**Visitors**
+* @nornagon
+
 ## Agenda
+
 1. Backports
-    - feat: add `process.getSystemVersion()` (backport: 5-0-x) [#17141](https://github.com/electron/electron/pull/17141)
+  * `feat: add process.getSystemVersion()` [#17141](https://github.com/electron/electron/pull/17141)
+  * Discussion about what the policy for backporting `semver-minor` features to active beta cycles should be
+    * Should there be a point during the beta cycle beyond which we no longer accept semver-minor?
+      * **VERDICT: NO**
+      * Instead, the bar for accepting semver-minor backports should be that there's a good justification (as determined by the releases wg) 
+        * The champion of a particular backport should expect to attend the WG meeting where it is being discussed in order to give that justification.
+2. What's the goal for how long `master` -> `stable` should be?
+  * Chrome is ~12 weeks, should we match that?
+  * [Insitgating Issue Comment](https://github.com/electron/roller/pull/8#issuecomment-467996465)
+  * Should we speed up releases?
+    * How long should it be from master -> stable?
+    * How long should it be between stable releases?
+  * @ckerr and @codebytere mention that people seem to be happy with the 12-week cadence
+    * If we change it, we should consult with AFP
+    * Actually, the release time we care about is Chrome `stable` -> Electron stable, not Electron `master` -> Electron `stable`
+    * General agreement that we should aim to match Chrome's release structure (canary / dev / beta / stable)
+      * This would mean a fairly major change to our versioning structure
+      * **ACTION ITEM:** keep talking about it :)
 
-    - discussion of what the policy for backporting semver-minor features to active beta cycles
-        - should there be a point during the beta cycle beyond which we no longer accept semver-minor?
-            - no
-            - the bar for accepting semver-minor backports should be that there's a good justification (as determined by the releases wg)
+Suggestion: we should to move the start of this meeting earlier by 15 minutes, to give extra time in case of spillover
+    - **VERDICT: YES**
 
-2. suggestion to move the start of this meeting earlier by 15 minutes, to give extra time in case of spillover
-    - sounds good
+## Follow-Up Discussion
 
-3. What's the goal for how long master -> stable should be? Chrome is ~12 weeks, should we match that?
-    - https://github.com/electron/roller/pull/8#issuecomment-467996465
-    - should we speed up releases? how long should it be from master -> stable? how long should it be between stable releases?
-    - charles and shelley mention that people seem to be happy with the 12-week cadence
-    - if we change it, we should consult with AFP
-    - actually the release time we care about is Chrome stable -> Electron stable, not Electron master -> Electron stable
-    - Should we match Chrome's release schedule?
-    - General agreement that we should aim to match Chrome's release structure (canary / dev / beta / stable)
-    - this would mean a fairly major change to our versioning structure
-    - ACTION: keep talking about it :)
-
-Didn't get to:
-- npm module organization
+1. Should our release schedule match Chromium's?
+2. `npm` module organization
     - `electron` vs `electron-nightly`
-- Process of adding new Releases WG members 
-
-## Follow-Up
-
-- Should our release schedule match Chromium's?
+3. Process of adding new Releases WG members 


### PR DESCRIPTION
Copyedit and organize meeting minutes from 2/27 to match formatting and organization of the previous minutes.

cc @electron/wg-releases 