### PR TITLE
feat: add proposed permission policy for npm

### DIFF
--- a/policy/permissions.md
+++ b/policy/permissions.md
@@ -76,7 +76,7 @@ The Twitter account is currently owned by GitHub and access is managed by them. 
 
 ### Access to the "electron" Organization on NPM
 
-All [maintainers](../charter.md#definitions) are entitled to be a "member" of the electron organization on NPM.  Permissions on on the `npm` org are managed by the Security Working Group.  Head over to the `#wg-security` channel on Slack to ask to be added.  By default you will be added to the `developers` team.  At a minimum your `npm` account must have `auth-only` 2FA configured.
+All [maintainers](../charter.md#definitions) are entitled to be a "member" of the electron organization on NPM.  Permissions on on the `npm` org are managed by the Security Working Group.  Head over to the `#wg-security` channel on Slack to ask to be added.  By default you will be added to the `developers` team.  At a minimum your `npm` account must have `auth-and-write` 2FA configured.
 
 #### NPM Teams
 
@@ -86,7 +86,7 @@ There are three teams on NPM, `developers`, `cfa`, `electron`.
 * `cfa` will have `read/write` on all packages with the exception of the "electron" package.
 * `electron` will have `read/write` on **only** the "electron" package.
 
-The only user in the `electron` team will be the "electron" user itself.  As such the only user with permission to publish the `electron` package should always be "electron".  Publishing of this package will be triggered through `sudowoodo`.
+The only user in the `electron` team will be the "electron-bot" user.  As such the only user with permission to publish the `electron` package should always be "electron-bot".  Publishing of this package will be triggered through `sudowoodo`.
 
 The only user in the `cfa` team will be the "electron-cfa" user.  As such the only user with permission to publish packages in the `electron` organization should be "electron-cfa".  As no humans have publish rights to any of these packages they should all be configured with `semantic-release` and the `@electron/semantic-release-npm-cfa` plugin.  For information on how to configure this plugin for use with a new package head over to [`electron/cfa`](https://github.com/electron/cfa).
 
@@ -94,13 +94,13 @@ The only user in the `cfa` team will be the "electron-cfa" user.  As such the on
 
 No human should ever have publish rights on their personal `npm` account to any Electron NPM package.
 
-### `electron` credentials
+### `electron-bot` credentials
 
-Credentials for the "electron" user will be stored on the 1-Password, access to these credentials will be controlled by the Releases Working Group.  Access to the 2FA secret for this account will be administered separately to the username/password as the entire Releases Working Group needs the 2FA secret to approve releases.
+Credentials for the "electron-bot" user will be stored on the 1-Password, access to these credentials will be controlled by the Releases Working Group.  Access to the 2FA secret for this account will be administered separately to the username/password as most of the Releases Working Group needs the 2FA secret to approve releases.
 
 ### `electron-cfa` credentials
 
-Credentials for the "electron-cfa" user will be stored on the 1-Password, access to these credentials will be controlled by the Docs and Tools Working Group.  Access to the 2FA secret for this account will be administered separately to the username/password as the entire Docs and Tools Working Group needs the 2FA secret to approve releases.
+Credentials for the "electron-cfa" user will be stored on the 1-Password, access to these credentials will be controlled by the Docs and Tools Working Group.  Access to the 2FA secret for this account will be administered separately to the username/password as most of the Docs and Tools Working Group needs the 2FA secret to approve releases.
 
 ## Exceptions
 


### PR DESCRIPTION
This permissions proposal introduces two new concepts that I'll run through below.

#### CFA

CFA is a service I'm currently building that extracts and extends on Sudowoodo's 2FA logic to allow us to set up `semantic-release` (automatic releases) for our npm packages while still having 2FA turned on.  I'm still working on it and I hope to have one of our `npm` packages working on that system early next week.

#### 1 Password

This is in here but only as a proposal, there is an agenda item in the next Security WG meeting to discuss whether or not we should go down the path of using 1 Password to share secrets / credentials.

Please do not merge this PR until Tuesday 10am PST at the earliest
