### PR TITLE
feat: update code owners for C&S WG

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 
 # Working Group Directories
 /wg-docs-tools/ @electron/wg-docs-tools
+/wg-community-safety/ @electron/wg-community-safety
 /wg-releases/ @electron/wg-releases
 /wg-upgrades/ @electron/wg-upgrades
 /wg-website/ @electron/wg-website


### PR DESCRIPTION
Updating directory permissions to reflect C&S WG.

**WARNING:** This PR should be merged only after GitHub team name is updated to `wg-community-safety`.