### PR TITLE
docs: Initial draft of interest groups

### DIFF
--- a/charter/interest-groups.md
+++ b/charter/interest-groups.md
@@ -10,7 +10,7 @@ Interest groups are a mechanism in Electron governance that allow individuals to
 
 ## Membership
 Membership into interest groups are open to anyone in the Electron Maintainers group in good standing.
-Interest groups will be listed in this repository with a link for maintainers to ask 
+Interest groups will be listed in this repository with a link for maintainers to fill out a form to join an interest group.
 
 ## Interest Group PR Workflow
 1. When a PR is created, the template for the PR will include a link to the list of interest groups so that the PR creator has a list of group(s) to ask for review from.


### PR DESCRIPTION
One of the items coming out of our discussions about whether or not to have a JS API wg was this idea of interest groups: https://hackmd.io/H_FJTENsTAKCd54riu90pg#Interest-Groups.  This PR outlines the idea of what those interest groups could be.

At a high level I think interest groups fill the need we have for specific folks to provide input into Electron development in the areas they care about.