### PR TITLE
feat: add a first-warning playbook entry

### DIFF
--- a/playbooks/responses/first-warning.md
+++ b/playbooks/responses/first-warning.md
@@ -8,7 +8,7 @@ Moving forward, I would recommend reading and following the advice in [Creators,
 
 Just to be clear, you are welcome to continue participating in the following ways:
 
-1. submitting bug reports with enough detail to reproduce - ideally a [Fiddle](https://electronjs.org/fiddle) example
+1. submitting new bug reports with enough detail to reproduce - ideally a [Fiddle](https://electronjs.org/fiddle) example
 1. a new feature request with context
 1. logistical questions that may not be covered in the docs (e.g. asking about release timelines in a polite way)
 


### PR DESCRIPTION
As requested in the 2019-03-06 wg-community-safety meeting

sourced from @lee-dohm's comment at https://github.com/electron/electron/issues/17171\#issuecomment-469483441. Lightly edited to remove the references to ALL CAPS since that's overly specific for a playbook response.