### PR TITLE
docs: added clarification/explanation

### DIFF
--- a/wg-releases/meeting-minutes/3-6-19.md
+++ b/wg-releases/meeting-minutes/3-6-19.md
@@ -33,7 +33,7 @@
 4. Should we publish linux 32-bit binaries?
   * They're no longer supported by Chrome, but they are published for Chromium (eg see https://chromium.woolyss.com/#linux)
   * Make it clear we won't prioritize fixes, or just not publish the binaries at all?
-  * **Resolved** Keep shipping the binaries for the time being but flag them as unsupported in electron-download and subject to disappear at anytime.  This was decided because it doesn't cost much to continue to make the releases available.  If at some point the maintenance around these releases becomes too much, those assets will be removed from the release assets.
+  * **Resolved** Keep shipping the binaries for the time being but flag them as unsupported in electron-download and subject to removal at anytime.  This was decided because it doesn't cost much to continue to make the releases available.  If at some point the maintenance around these releases becomes too much, those assets will be removed from the release assets.
 
 ## Action Items
 


### PR DESCRIPTION
The question was brought up about why we decided to continue releasing ia32 linux, so I updated the notes to include more of our conversation/reasoning on this subject.