### PR TITLE
fix: spelling errors & capitalization

### DIFF
--- a/charter/interest-groups.md
+++ b/charter/interest-groups.md
@@ -1,6 +1,6 @@
 # Interest Groups
 Interest groups are a mechanism in Electron governance that allow individuals to provide input into specific categories of Electron development.  These groups would provide input into Electron development via the following processes:
-* Reviewing [electron/electron](https://github.com/electron/electron) PRs that have revelance to the interest group.
+* Reviewing [electron/electron](https://github.com/electron/electron) PRs that have relevance to the interest group.
 * Creating and commenting on RFCs/Intent To Ship issues related to the interest group.
 
 ## Possible Interest Groups

--- a/policy/permissions.md
+++ b/policy/permissions.md
@@ -62,7 +62,7 @@ In a variety of situations, some [collaborators](../charter.md#definitions) may 
 * Members of the AFP should be added as single-channel guests to the
 `#app-feedback-program` channel.
 
-Before a Guest is added to a channel it must be announced in that channel to ensure that all current members are aware a guest is now in that channel.  As only Slack Owners can invite guests it is their responsibility to ensure that all members of a given channel are ok with the addition of a guest.
+Before a Guest is added to a channel it must be announced in that channel to ensure that all current members are aware a guest is now in that channel.  As only Slack Owners can invite guests it is their responsibility to ensure that all members of a given channel are OK with the addition of a guest.
 
 ### Private Slack Channels
 

--- a/pull-requests.md
+++ b/pull-requests.md
@@ -12,7 +12,7 @@ If the PR fixes an issue, the PR must mention that issue in the PR body, e.g. [F
 
 Pull Requests whose changes affect end-users should stay open for at least 24 hours. This is to allow for input from all timezones
 
-Unless other argeements have been made, people should allow 24 hours before pinging folks for review or re-review.
+Unless other agreements have been made, people should allow 24 hours before pinging folks for review or re-review.
 
 If a PR has a time constraint, the person requesting review should use their best judgement for when to ping people.
 

--- a/wg-community-safety/README.md
+++ b/wg-community-safety/README.md
@@ -19,7 +19,7 @@ Oversees removal/bans from community.
 - Approval of adding and removing Slack Owners / Admins.
 - Adding and removing Slack members.
     - Non governance members are multi channel guests.
-- Dealing with CoC issues that happen during events, in Slack, and on GitHub.
+- Dealing with Code of Conduct issues that happen during events, in Slack, and on GitHub.
 - Banning GitHub users on repos and issues.
 - Helping arbitrate disagreements between contributors.
 

--- a/wg-releases/meeting-notes/2019-02-27.md
+++ b/wg-releases/meeting-notes/2019-02-27.md
@@ -19,11 +19,11 @@
   * Discussion about what the policy for backporting `semver-minor` features to active beta cycles should be
     * Should there be a point during the beta cycle beyond which we no longer accept semver-minor?
       * **Resolved** No
-      * Instead, the bar for accepting semver-minor backports should be that there's a good justification (as determined by the releases wg) 
+      * Instead, the bar for accepting semver-minor backports should be that there's a good justification (as determined by the releases WG) 
         * The champion of a particular backport should expect to attend the WG meeting where it is being discussed in order to give that justification.
 2. What's the goal for how long `master` -> `stable` should be?
   * Chrome is ~12 weeks, should we match that?
-  * [Insitgating Issue Comment](https://github.com/electron/roller/pull/8#issuecomment-467996465)
+  * [Instigating Issue Comment](https://github.com/electron/roller/pull/8#issuecomment-467996465)
   * Should we speed up releases?
     * How long should it be from master -> stable?
     * How long should it be between stable releases?

--- a/wg-releases/meeting-notes/2019-03-06.md
+++ b/wg-releases/meeting-notes/2019-03-06.md
@@ -30,7 +30,7 @@
       * Update electron to 4.1 and tell all package maintainers to build a new release of their native module for 4.1
       * Update node-pre-gyp as outlined above and tell all package maintainers to update node-pre-gyp and build a new release of their native module
     * **Resolved** Update Electron to `4.1` and abandon `4.0`
-4. Should we publish linux 32-bit binaries?
+4. Should we publish Linux 32-bit binaries?
   * They're no longer supported by Chrome, but they are published for Chromium (eg see https://chromium.woolyss.com/#linux)
   * Make it clear we won't prioritize fixes, or just not publish the binaries at all?
   * **Resolved** Keep shipping the binaries for the time being but flag them as unsupported in electron-download and subject to removal at anytime.  This was decided because it doesn't cost much to continue to make the releases available.  If at some point the maintenance around these releases becomes too much, those assets will be removed from the release assets.

--- a/wg-security/membership-and-notifications.md
+++ b/wg-security/membership-and-notifications.md
@@ -7,7 +7,7 @@ Due to the Security Working Group's sensitive role in responding to newly-report
 
 People who want to join the Security WG should apply by notifying the WG, which will then vote at the next meeting. The vote shall be recorded only as "was accepted" or "was not accepted" rather than how each member voted.
 
-When voting, members should consider: has the person shown a history of Electron maintainence that indicates they could contribute to the fixing of security issues? For example, do they have a history of commits to Electron? Have they worked with other maintainers in a constructive way?
+When voting, members should consider: has the person shown a history of Electron maintenance that indicates they could contribute to the fixing of security issues? For example, do they have a history of commits to Electron? Have they worked with other maintainers in a constructive way?
 
 Based on that criteria, the WG encourages people whose applications were declined to continue collaborating with other maintainers, to continue landing PRs, to participate in other Working Groups, and to re-apply in the future. 
 

--- a/wg-upgrades/meeting-notes/2019-03-05.md
+++ b/wg-upgrades/meeting-notes/2019-03-05.md
@@ -64,4 +64,4 @@
     * embedders use a "linked" binding
     * ... which isn't tested and might not work???
     * anna will join the #wg-upgrades channel
-* @nornagon to fix linux failures on M74
+* @nornagon to fix Linux failures on M74


### PR DESCRIPTION
This PR fixes spelling errors that I found by feeding the repo into a spellchecker.

Nothing big; it's stuff like:
 * revelance -> relevance
 * linux -> Linux