### PR TITLE
fix: remove references to daylight savings / standard time

### DIFF
--- a/wg-community-safety/README.md
+++ b/wg-community-safety/README.md
@@ -28,7 +28,7 @@ All repositories under electron org.
 
 ## Meeting Schedule
 
-* **Sync Meeting** 60 min every other Thursday at 15:00 UTC
+* **Sync Meeting** 60 min every other Thursday at [15:00 UTC](https://duckduckgo.com/?q=15%3A00+UTC&ia=answer)
 * On an as needed basis
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-docs-tools/README.md
+++ b/wg-docs-tools/README.md
@@ -35,7 +35,7 @@ These projects are sorted alphabetically, their order does not reflect that any 
 * Tools (Userland)
   * Download
   * electron-compile
-  * electron-installer-*
+  * electron-installer-\*
   * Forge
   * osx-sign
   * Packager
@@ -81,6 +81,6 @@ These repos are sorted alphabetically, their order does not reflect that any of 
 
 ## Meeting Schedule
 
-**Sync Meeting** 30min every other Thursday @ 16:00 UTC
+**Sync Meeting** 30min every other Thursday @ [16:00 UTC](https://duckduckgo.com/?q=16%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -22,6 +22,6 @@ Grows the Electron community
 - Electron meetup events
 
 ## Meeting Schedule
-- **Sync Meeting** 60 min meeting every other Monday @ 17:00 UTC
+- **Sync Meeting** 60 min meeting every other Monday @ [17:00 UTC](https://duckduckgo.com/?q=17%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -36,7 +36,7 @@ See [repos.md](repos.md)
 
 ## Meeting Schedule
 
-* **Sync Meeting** 45 min every Wednesday at 11:00PM UTC
-* **Major Release Cadence Meeting** 1 hour every Thursday at 12:00AM UTC
+* **Sync Meeting** 45 min every Wednesday at [23:00 UTC](https://duckduckgo.com/?q=23%3A00+UTC&ia=answer)
+* **Major Release Cadence Meeting** 1 hour every Thursday at [00:00AM UTC](https://duckduckgo.com/?q=00%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-upgrades/README.md
+++ b/wg-upgrades/README.md
@@ -32,6 +32,6 @@ See [repos.md](repos.md)
 
 ## Meeting Schedule
 
-* **Sync Meeting** 60 min every Tuesday @ 16:00 UTC
+* **Sync Meeting** 60 min every Tuesday @ [16:00 UTC](https://duckduckgo.com/?q=16%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-website/README.md
+++ b/wg-website/README.md
@@ -28,6 +28,6 @@ Oversees the technical implementation, design, and style of the Electron website
 
 ## Meeting Schedule
 
-**Sync Meeting** 30min every other Thursday @ 16:00 UTC
+**Sync Meeting** 30min every other Thursday @ [16:00 UTC](https://duckduckgo.com/?q=16%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).


### PR DESCRIPTION
Another ground-shaking PR to go along with the [spellcheck](https://github.com/electron/governance/pull/48) PR.

Removes references to standard/daylight time so that meeting times aren't invalidated when Pacific Time switches between daylight and standard time.

For example:

```diff
- Meeting time: 10 AM PST
+ Meeting time: 10 AM PT
```