### PR TITLE
chore: Add charter doc to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Administration Files
 */repositories.md @electron/wg-admin
 /policy/ @electron/wg-admin
+/charter/README.md @electron/wg-admin
 
 # Working Group Directories
 /wg-docs-tools/ @electron/wg-docs-tools


### PR DESCRIPTION
Charter doc was moved in #44.