### PR TITLE
docs(wg notes): add 2019-03-20 Release WG notes

### DIFF
--- a/wg-releases/meeting-notes/2019-03-20.md
+++ b/wg-releases/meeting-notes/2019-03-20.md
@@ -1,0 +1,39 @@
+# Release WG Minutes
+
+### Date: 3-20-19 
+
+## Attendees
+
+**Members**
+
+@codebytere
+@ckerr
+@jkleinsc
+@MarshallofSound
+
+**Visitors**
+
+@nornagon
+
+## Agenda
+
+1. `5.0.0-beta.6` release. It's been 15 days since the last beta release
+    * **Verdict:** this is done.
+2. Electron/Chromium release schedule coordination
+    * **Verdict:** formalize a 12 week release cycle
+3. What should we do about the bugs in [`4-0-x`](https://github.com/orgs/electron/projects/17 ) now that the line is deprecated and we are not maintaining?
+    * 4-1-x bugs are the exact same, it's the same branch with a few extra things on it
+    * **Verdict:** Rename `4-0-x` label to `4-1-x` and the `4-0-x` board to `4-1-x`.
+
+## Action Items
+
+* Formalize a 12-week release schedule and update versioning document with it (@MarshallOfSound)
+* Migrate 4-0-x bugs to 4-1-x label (@MarshallOfSound)
+
+## Follow-Up Discussion
+
+None.
+
+## Backport Requests
+
+**Nota Bene:** If you are the requester, you are generally expected to attend the meeting. If you are unable to do so, please state your reason for requesting the backport.


### PR DESCRIPTION
Adds Meeting Notes from the 3/20/2019 Releases WG meeting.

cc @electron/wg-releases 