### PR TITLE
docs: add JD build notes to 2019-04-01 outreach notes

### DIFF
--- a/wg-outreach/meeting-notes/2019-04-01.md
+++ b/wg-outreach/meeting-notes/2019-04-01.md
@@ -17,7 +17,9 @@ April 1, 2019
     * https://github.com/electron/electron/issues/17456 
     * run through of electron build for macOS (sofia), windows (JD), and linux (david)
         * Sofia on macOS: all told, took 5-6 hours including troubleshooting
-        * Sofia's notes from building electron on MacOS: https://hackmd.io/Ef3mj2xXTBKR9grGsSZHog?both 
+        * Sofia's notes from building electron on MacOS: https://hackmd.io/Ef3mj2xXTBKR9grGsSZHog?both
+        * JD on Windows 10: all told, took days including troubleshooting
+        * JD's notes from buildong electron on Windows 10: https://hackmd.io/s/rJ67Tjc5V
     * Mentorship
     * suggestion: Slack onboarding doc includes who to reach out to, which channels to join, and what to do when you're bored 
 


### PR DESCRIPTION
This PR adds build notes for Windows to the 2019-04-01 outreach wg notes.