### PR TITLE
docs: add (more) assoc repos to release wg

### DIFF
--- a/wg-releases/repos.md
+++ b/wg-releases/repos.md
@@ -4,4 +4,6 @@
 - [`electron/trop`](https://github.com/electron/trop)
 - [`electron/sudowoodo`](https://github.com/electron/sudowoodo)
 - [`electron/nightlies`](https://github.com/electron/nightlies)
+- [`electron/cation`](https://github.com/electron/cation)
 - [`electron/clerk`](https://github.com/electron/clerk)
+- [`electron/unreleased`](https://github.com/electron/unreleased)


### PR DESCRIPTION
Marks [`electron/cation`](https://github.com/electron/cation) and [`electron/unreleased`](https://github.com/electron/unreleased) as owned by @electron/wg-releases.