### PR TITLE
docs: add 2019-05-09 Docs and Tools WG meeting notes

### DIFF
--- a/wg-docs-tools/meeting-notes/2019-05-09.md
+++ b/wg-docs-tools/meeting-notes/2019-05-09.md
@@ -1,18 +1,16 @@
 # Docs & Tools WG meeting 2019-05-09
 
-Thursday, May 09, 2019 (9:00-9:30am PT)
-https://github.zoom.us/my/electron
-
 ## Attendees
+ @Hashimoto
+ @ckerr
+ @killian
  
 ## Agenda
- 
-*Add items here for them to be discussed in the meeting along with your name*
 
 1. Unified Documentation 
+    * Reiteration of goals from ckerr: have a single set of sample code that can be shared across website, Fiddle, and api-demos; make electronjs.org/docs more organized & navigatable, increase the number of code samples so that new users will know how to do anything in Electron
     * Launching code examples from docs into Fiddle (@ckerr)
     * What changes would we need to make to the docs in `electron/electron`? (@ckerr)
-    * Embed Fiddle gists as code samples? (@malept)
 
 1. Making 'Breaking Changes' more discoverable
     * Kilian points out this is useful to link to in release notes
@@ -23,11 +21,16 @@ https://github.zoom.us/my/electron
  * Open tracking issue for electronjs.org/docs page brainstorming & improvements (@ckerr)
  * Add link to 'Breaking Changes' in release notes script? Open issue & get feedback from Releases WG (@ckerr)
 
-## Followup
+## Future Agenda
+
+1. Unified Documentation
+    * Embed Fiddle gists as code samples? (@malept)
 
 1. How the [Squirrel.Windows deprecation](https://github.com/electron/electron/issues/17722) affects us (@malept)
     * [Reboot proposal from @shiftkey](https://github.com/Squirrel/Squirrel.Windows/issues/1470)
     * Someone from governance should be a part of talks if they aren't already
+
 1. `electron-prebuilt-compile` follow-up (@malept, for @felix)
+
 1. `@electron/download` update (@malept, @MarshallOfSound)
     * Needs to be renamed something else due to NPM naming restrictions

--- a/wg-docs-tools/meeting-notes/2019-05-09.md
+++ b/wg-docs-tools/meeting-notes/2019-05-09.md
@@ -1,0 +1,33 @@
+# Docs & Tools WG meeting 2019-05-09
+
+Thursday, May 09, 2019 (9:00-9:30am PT)
+https://github.zoom.us/my/electron
+
+## Attendees
+ 
+## Agenda
+ 
+*Add items here for them to be discussed in the meeting along with your name*
+
+1. Unified Documentation 
+    * Launching code examples from docs into Fiddle (@ckerr)
+    * What changes would we need to make to the docs in `electron/electron`? (@ckerr)
+    * Embed Fiddle gists as code samples? (@malept)
+
+1. Making 'Breaking Changes' more discoverable
+    * Kilian points out this is useful to link to in release notes
+    * If we use the same terminology and link to this in every release notes post, developers will know to use that.
+
+## Action Items
+
+ * Open tracking issue for electronjs.org/docs page brainstorming & improvements (@ckerr)
+ * Add link to 'Breaking Changes' in release notes script? Open issue & get feedback from Releases WG (@ckerr)
+
+## Followup
+
+1. How the [Squirrel.Windows deprecation](https://github.com/electron/electron/issues/17722) affects us (@malept)
+    * [Reboot proposal from @shiftkey](https://github.com/Squirrel/Squirrel.Windows/issues/1470)
+    * Someone from governance should be a part of talks if they aren't already
+1. `electron-prebuilt-compile` follow-up (@malept, for @felix)
+1. `@electron/download` update (@malept, @MarshallOfSound)
+    * Needs to be renamed something else due to NPM naming restrictions


### PR DESCRIPTION
Add meeting notes for the 2019-05-09 Docs & Tools WG meeting.