### PR TITLE
docs: new backport rule

### DIFF
--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -40,3 +40,6 @@ See [repos.md](repos.md)
 * **Major Release Cadence Meeting** 1 hour every Thursday at [00:00AM UTC](https://duckduckgo.com/?q=00%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).
+
+## Feature Backport Requests for Major Versions in Beta
+With our 12-week major release cadence, we are _not_ considering feature backport requests after Week 3 of each beta cycle. Backport requests after Week 3 will only be considered if there is a very good reason. For backport requests please submit the link to the PR and reason for backport to the Releases WG agenda for consideration.


### PR DESCRIPTION
Adding new backport rule from output of [Releases WG 5/15 meeting](https://github.com/electron/governance/blob/master/wg-releases/meeting-notes/2019-05-15.md#action-items)