### PR TITLE
docs: add WG Releases notes for 6/26

### DIFF
--- a/wg-releases/meeting-notes/2019-06-26.md
+++ b/wg-releases/meeting-notes/2019-06-26.md
@@ -1,0 +1,44 @@
+# Releases WG
+
+### Date: 2019-06-26
+
+## Attendees
+
+**Members**
+* @ckerr
+* @codebytere
+* @deepak1556
+* @deermichel
+* @erickzhao
+* @jkleinsc
+* @sofianguy
+* @marshallofsound
+
+**Visitors**
+None
+
+## Agenda
+
+ *  Everyone should fill out [this form to help set the agenda](https://docs.google.com/forms/d/e/1FAIpQLSeOCd4eAi_pfNvyaoS0L8bFRkDIaJy2_H0SlJwRW3lHl9Q64g/viewform) of the [upcoming Electron Maintainers Summit](https://docs.google.com/document/d/10xwcjdw--g4m_1O8WCnyGOCO8F4aNP5wnRYeUMARcVU/edit)
+ *  Should we publish tags to both `e/e` _and_ the nightlies repo?
+     *  **@ckerr** rightly mentioned that this can be confusing since it's not clear immediately where the executables are located
+     *  **Verdict:** we should reference website for releases instead of GitHub 
+* Thoughts on [#18981](https://github.com/electron/electron/pull/18981)?
+    * **Verdict:** Deprecate in 6, remove in 7
+
+## Backport Requests
+
+- [feat: add app.disablePluginSandbox(mimeType)](https://github.com/electron/electron/pull/18939)
+  - Requesting backport to 6-0-x
+  - This mitigates the breaking change of enabling mixed sandbox by default on pepper plugins, which are now sandboxed as well, without being configurable
+  - **Verdict:** Passing buck to upgrades
+
+**Nota Bene:** If you are the requester, you are generally expected to attend the meeting. If you are unable to do so, please state your reason for requesting the backport.
+ 
+## Action Items
+
+* Update the documentation to reference the website for release types instead of the Releases tab
+
+## Follow-Up Discussion
+
+None.


### PR DESCRIPTION
Notes from today.

cc @electron/wg-releases 