### PR TITLE
docs: default email for requests to be placed on the website

### DIFF
--- a/wg-website/emails/request-for-link-on-site.md
+++ b/wg-website/emails/request-for-link-on-site.md
@@ -1,6 +1,6 @@
 Hi $REQUESTER,
 
-I'm $NAME, the current chair of Electron’s Website Working group. Thank you for your email and thank you for your interest in supporting Electron!
+I'm $NAME, [the current chair | a member] of Electron’s Website working group. Thank you for your email and thank you for your interest in supporting Electron!
 
 The logos displayed under "Built on Electron" are from our App Feedback Program members. This is a program for companies using Electron for their apps where they can give early feedback on testing betas of our major versions. This helps us prioritize the work that makes the greatest impact for them. If this interests you, please check out this page with more information on how to join: [Electron App Feedback Program](https://electronjs.org/blog/app-feedback-program).
 

--- a/wg-website/emails/request-for-link-on-site.md
+++ b/wg-website/emails/request-for-link-on-site.md
@@ -1,4 +1,4 @@
-Hi Michaela,
+Hi $REQUESTER,
 
 I'm $NAME, the current chair of Electron’s Website Working group. Thank you for your email and thank you for your interest in supporting Electron!
 

--- a/wg-website/emails/request-for-link-on-site.md
+++ b/wg-website/emails/request-for-link-on-site.md
@@ -1,0 +1,12 @@
+Hi Michaela,
+
+I'm $NAME, the current chair of Electron’s Website Working group. Thank you for your email and thank you for your interest in supporting Electron!
+
+The logos displayed under "Built on Electron" are from our App Feedback Program members. This is a program for companies using Electron for their apps where they can give early feedback on testing betas of our major versions. This helps us prioritize the work that makes the greatest impact for them. If this interests you, please check out this page with more information on how to join: [Electron App Feedback Program](https://electronjs.org/blog/app-feedback-program).
+
+All the applications on the Electron site come from the [Electron apps repository on Github](https://github.com/electron/apps). If you open a pull request in that repository, your applications will also show up on the website. For more help on this, check out the [contributing guide](https://github.com/electron/apps/blob/master/contributing.md).
+
+If you have any more questions, please let me know and I'd be happy to answer them.
+
+Best,
+$NAME


### PR DESCRIPTION
This email was recently discussed in the slack chat, documenting it here for future use.