### PR TITLE
docs: Releases WG major version release schedule

### DIFF
--- a/wg-releases/major-version-release-schedule.md
+++ b/wg-releases/major-version-release-schedule.md
@@ -46,3 +46,10 @@
 | Week 11 | 2019-10-18 | Stable prep items due | Stable Prep Week 🚧 |
 | Week 12 | 2019-10-21 | Kick off 7.0.0 release | Action Item |
 | Week 12 | 2019-10-22 | 7.0.0 | Stable Deadline ✨ |
+
+## 8.0.0
+| Week # | Date  | Event | Comments |
+| ------ | ----- | ----- | -------- |
+| Week 0 | 2019-10-23 | Kick off 8.0.0-beta.1 | Action Item |
+| Week 0 | 2019-10-24 | 8.0.0-beta.1 | beta.1 deadline |
+| Week 1 | 2019-10-28 | | |

--- a/wg-releases/major-version-release-schedule.md
+++ b/wg-releases/major-version-release-schedule.md
@@ -1,0 +1,48 @@
+# Major Version Release Schedule
+
+## 6.0.0
+| Week # | Date  | Event | Comments |
+| ------ | ----- | ----- | -------- |
+| Week 1 | 2019-04-30 | 6.0.0-beta.1 | 🔥 |
+| Week 2 | 2019-05-07 | 6.0.0-beta.2 | |
+| Week 3 | 2019-05-14 | 6.0.0-beta.3 | |
+| Week 4 | 2019-05-21 | 6.0.0-beta.4 | |
+| Week 5 | 2019-05-29 | 6.0.0-beta.5 | |
+| Week 6 | 2019-06-04 | 6.0.0-beta.6 | halfway point |
+| Week 7 | 2019-06-11 | 6.0.0-beta.7 | |
+| Week 7 | 2019-06-14 | 6.0.0-beta.8 | |
+| Week 8 | 2019-06-18 | 6.0.0-beta.9 | |
+| Week 8 | 2019-06-21 | 6.0.0-beta.10 | |
+| Week 9 | 2019-06-25 | 6.0.0-beta.11 | |
+| Week 10 | 2019-07-03 | 6.0.0-beta.12 | |
+| Week 11 | 2019-07-10 | 6.0.0-beta.13 | |
+| Week 11 | 2019-07-12 | Last day for AFP 6.0 bug reports | |
+| Week 12 | 2019-07-17 | 6.0.0-beta.14 | |
+| Week 12 | 2019-07-19 | Target: Last day for 6.0.x PRs | |
+| Week 12 | 2019-07-19 | 6.0.0-beta.15 | Final beta release |
+| Week 13 | 2019-07-26 | Stable prep items due | Stable Prep Week 🚧 |
+| Week 14 | 2019-07-29 | kick off 6.0.0 release | Action Item |
+| Week 14 | 2019-07-30 | 6.0.0 | Stable Deadline ✨ |
+
+## 7.0.0
+| Week # | Date  | Event | Comments |
+| ------ | ----- | ----- | -------- |
+| Week 0 | 2019-07-31 | kick off 7.0.0-beta.1 | Action Item |
+| Week 0 | 2019-08-01 | 7.0.0-beta.1 | beta.1 deadline |
+| Week 1 | 2019-08-05 | 7.0.0-beta.2 | |
+| Week 2 | 2019-08-12 | 7.0.0-beta.3 | |
+| Week 3 | 2019-08-19 | 7.0.0-beta.4 | |
+| Week 3 | 2019-08-23 | Last day for accepting feature backports | |
+| Week 4 | 2019-08-26 | 7.0.0-beta.5 | |
+| Week 5 | 2019-09-02 | 7.0.0-beta.6 | |
+| Week 6 | 2019-09-09 | Electron Maintainer Summit | No releases. Halfway point. |
+| Week 7 | 2019-09-16 | 7.0.0-beta.7 | |
+| Week 8 | 2019-09-23 | 7.0.0-beta.8 | |
+| Week 9 | 2019-09-30 | 7.0.0-beta.9 | |
+| Week 9 | 2019-10-04 | Last day for AFP 7.0 bug reports | |
+| Week 10 | 2019-10-07 | 7.0.0-beta.10 | |
+| Week 10 | 2019-10-10 | Target: Last day for 7-0-x PRs | |
+| Week 11 | 2019-10-11 | 7.0.0-beta.11 | Action: Release final beta |
+| Week 11 | 2019-10-18 | Stable prep items due | Stable Prep Week 🚧 |
+| Week 12 | 2019-10-21 | Kick off 7.0.0 release | Action Item |
+| Week 12 | 2019-10-22 | 7.0.0 | Stable Deadline ✨ |


### PR DESCRIPTION
As discussed in our meeting this week, we are going to move our internal working calendar for major version releases to our directory and the public facing [timeline doc](https://electronjs.org/docs/tutorial/electron-timelines) will just show beta.1 & stable dates to declutter the public page. 

The dates listed in this file will be synced up to the Google calendar that posts into #wg-releases channel.