### PR TITLE
docs: add major release line prep doc

### DIFF
--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -60,6 +60,6 @@ For this, we need to ensure the following:
   * If we've just released `v6.0.0`, this means that `7-0-x` is about to become the beta line, and so we would need to procure a NMV for `8-0-x`
 * Sudowoodo is capable of handling betas for the new major line
 * [`node-abi`](https://github.com/lgeiger/node-abi) beta update
-  * We should ensure that  abi version information is added for the first beta in the new major stabilization line
+  * We should ensure that ABI version information is added for the first beta in the new major stabilization line
     * See [this PR](https://github.com/lgeiger/node-abi/pull/67) for an example
   

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -4,7 +4,7 @@ This document outlines the major release stable promotion process.
 
 ## Final Beta Release
 
-One week before stable promotion for a given release line, we should release a final beta with ideally few changes. This means that for a stable release date of Tuesday, we should be releasing a final beta the friday a full > 1 week preceding that Tuesday, to allow for a quiet period week to account for complications.
+One week before stable promotion for a given release line, we should release a final beta with ideally few changes. This means that for a stable release date of Tuesday, we should be releasing a final beta the Friday a full > 1 week preceding that Tuesday, to allow for a quiet period week to account for complications.
 
 Before releasing the final beta, we need to ensure that there remain no unmerged pull requests targeting that branch. This entails two tasks:
 
@@ -13,19 +13,23 @@ Before releasing the final beta, we need to ensure that there remain no unmerged
 
 If both tasks are complete, proceed with the final beta release.
 
-## Communications Preparation
+## Stable Preparation
 
 We need to ensure the following have owners and have been completed:
 
-1) Blog Post
+* Blog Post
   * This post should contain the following:
-    * An update for which versions are now supported, and the new types of support for each of those (security-only, etc.)
+    * An update for which versions are now supported, and the new types of support for each of those (security-only, full support, etc.)
     * Link to timeline for subsequent major release
     * A list of breaking changes in the current stable line
     * References to any upcoming notable changes or deprecations
-2) Tweet - a tweet about the latest stable line & blog post from the official `@electronjs` twitter account
-3) Updates to [Supported Versions](https://github.com/electron/electron/blob/master/docs/tutorial/support.md#currently-supported-versions)
-4) Timeline for subsequent [major release version](https://electronjs.org/docs/tutorial/electron-timelines)
+* Tweet - a tweet about the latest stable line & blog post from the official `@electronjs` twitter account
+* Updates to [Supported Versions](https://github.com/electron/electron/blob/master/docs/tutorial/support.md#currently-supported-versions)
+* Timeline for subsequent [major release version](https://electronjs.org/docs/tutorial/electron-timelines)
+* [`node-abi`](https://github.com/lgeiger/node-abi) stable update
+  * Ensure that ABI version information is added for the first new stable version (Ex. `v6.0.0`)
+* [Spectron](https://github.com/electron-userland/spectron) update - a version of Spectron should be published compatible with the new stable release
+* [Chromedriver](https://github.com/electron/chromedriver) update - a version of Chromedriver should be published compatible with the version of Chromium being shipped in the new stable version
 
 ## Stable Release Promotion
 
@@ -42,16 +46,20 @@ Release Type: `Stable`
 
 Immediately following the release, we need to ensure the following:
 
-1) The [Electron Website](https://electronjs.org) reflects the latest stable version
-2) The `latest` tag on npm correctly reflects the new latest major release line
-3) The blog post has been successfully published to the [Electron Website](https://electronjs.org)
+* The [Electron Website](https://electronjs.org) reflects the latest stable version
+* The `latest` tag on npm correctly reflects the new latest major release line
+* The blog post has been successfully published to the [Electron Website](https://electronjs.org)
 
-## New Stable Preparations
+## Subsequent Release Line Preparations
 
 After a new major line has been officially stabilized, we should begin to prepare for the beta process of the next line.
 
 For this, we need to ensure the following:
 
-1) We have a new Node Module Version (NMV) for the line that follows what is about to become the new `master` major.
-  * If we've just released `v6.0.0`, this means that `7-0-x` is about to become the beta line, and so we would need to procure a NMV for `8-0-x`.
-2) Sudowoodo is capable of handling betas for the new major line.
+* We have a new Node Module Version (NMV) for the line that follows what is about to become the new `master` major
+  * If we've just released `v6.0.0`, this means that `7-0-x` is about to become the beta line, and so we would need to procure a NMV for `8-0-x`
+* Sudowoodo is capable of handling betas for the new major line
+* [`node-abi`](https://github.com/lgeiger/node-abi) beta update
+  * We should ensure that  abi version information is added for the first beta in the new major stabilization line
+    * See [this PR](https://github.com/lgeiger/node-abi/pull/67) for an example
+  

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -1,0 +1,57 @@
+# Major Release Process
+
+This document outlines the major release stable promotion process.
+
+## Final Beta Release
+
+One week before stable promotion for a given release line, we should release a final beta with ideally few changes. This means that for a stable release date of Tuesday, we should be releasing a final beta the friday a full > 1 week preceding that Tuesday, to allow for a quiet period week to account for complications.
+
+Before releasing the final beta, we need to ensure that there remain no unmerged pull requests targeting that branch. This entails two tasks:
+
+1) Run `/check-unmerged <branch-name>` in Slack and see if any PRs are returned
+2) Check open PRs to `master` on `electron/electron` and ensure that none of them carry the label `target/<branch-name>`
+
+If both tasks are complete, proceed with the final beta release.
+
+## Communications Preparation
+
+We need to ensure the following have owners and have been completed:
+
+1) Blog Post
+  * This post should contain the following:
+    * An update for which versions are now supported, and the new types of support for each of those (security-only, etc.)
+    * Link to timeline for subsequent major release
+    * A list of breaking changes in the current stable line
+    * References to any upcoming notable changes or deprecations
+2) Tweet - a tweet about the latest stable line & blog post from the official `@electronjs` twitter account
+3) Updates to [Supported Versions](https://github.com/electron/electron/blob/master/docs/tutorial/support.md#currently-supported-versions)
+4) Timeline for subsequent [major release version](https://electronjs.org/docs/tutorial/electron-timelines)
+
+## Stable Release Promotion
+
+The day before the publicly communicated date, we should begin the stable promotion process. This is to account for errors with processes out of our control, like CI errors or errors on npm.
+
+At approximately noon on that preceding day, a member of the Releases WG should trigger a release with Sudowoodo with the following parameters:
+
+```sh
+Release Branch: Stabilization Line (ie `6-0-x`)
+Release Type: `Stable`
+```
+
+## Immediately Following Release
+
+Immediately following the release, we need to ensure the following:
+
+1) The [Electron Website](https://electronjs.org) reflects the latest stable version
+2) The `latest` tag on npm correctly reflects the new latest major release line
+3) The blog post has been successfully published to the [Electron Website](https://electronjs.org)
+
+## New Stable Preparations
+
+After a new major line has been officially stabilized, we should begin to prepare for the beta process of the next line.
+
+For this, we need to ensure the following:
+
+1) We have a new Node Module Version (NMV) for the line that follows what is about to become the new `master` major.
+  * If we've just released `v6.0.0`, this means that `7-0-x` is about to become the beta line, and so we would need to procure a NMV for `8-0-x`.
+2) Sudowoodo is capable of handling betas for the new major line.

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -57,8 +57,7 @@ After a new major line has been officially stabilized, we should begin to prepar
 For this, we need to ensure the following:
 
 * We have a new Node Module Version (NMV) for the line that follows what is about to become the new `master` major
-  * If we've just released `v6.0.0`, this means that `7-0-x` is about to become the beta line, and so we would need to procure a NMV for `8-0-x`
-* Sudowoodo is capable of handling betas for the new major line
+* Sudowoodo is capable of handling betas for the new major line in its [release options](https://github.com/electron/sudowoodo/blob/master/src/slack-manager.ts#L240-L265)
 * [`node-abi`](https://github.com/lgeiger/node-abi) beta update
   * We should ensure that ABI version information is added for the first beta in the new major stabilization line
     * See [this PR](https://github.com/lgeiger/node-abi/pull/67) for an example

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -1,6 +1,6 @@
 # Major Release Process
 
-This document outlines the major release stable promotion process.
+This document outlines the beta -> stable promotion process for a major release.
 
 ## Final Beta Release
 


### PR DESCRIPTION
Per meeting discussion Wednesday, i've added a preliminary version of a Major Release Prep doc based on some of the tasks outlined [here](https://github.com/electron/electron/projects/20).

Please feel free to comment and leave feedback with any thoughts or things you feel may be missing here!

cc @electron/wg-releases 