### PR TITLE
feat: Outreach WG chair rotation

### DIFF
--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -4,10 +4,10 @@ Grows the Electron community
 ## Membership
 | Avatar | Name | Role | Time Zone |
 | ------ | ---- | ---- | --------- |
-| <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | **Chair** | PT (San Francisco) |
+| <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg">  | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | **Chair** | PT (San Francisco) |
+| <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
 | <img src="https://github.com/ckerr.png" width=100 alt="@ckerr">  | Charles Kerr [@ckerr](https://github.com/ckerr) | Member | CT (New Orleans) |
-| <img src="https://github.com/cruzerld.png" width=100 alt="@cruzerld">  | David Cruz [@cruzerld](https://github.com/cruzerld) | Member | CT (Austin) |
-| <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg">  | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | Member | PT (San Francisco) |
+| <img src="https://github.com/cruzerld.png" width=100 alt="@cruzerld">  | David Cruz [@cruzerld](https://github.com/cruzerld) | Member | ET (New York City) |
 | <img src="https://github.com/jdalton.png" width=100 alt="@jdalton">  | John-David Dalton [@jdalton](https://github.com/jdalton) | Member | PT (Seattle) |
 | <img src="https://github.com/BinaryMuse.png" width=100 alt="@BinaryMuse">  | Michelle Tilley [@BinaryMuse](https://github.com/BinaryMuse) | Member | PT (San Francisco) |
 | <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |


### PR DESCRIPTION
Outreach WG chair rotation was done async in #wg-outreach. Outcome is @felixrieseberg will be next Outreach WG chair starting immediately. 

I also added an update for @cruzerld's location.