### PR TITLE
feat: explain how new participants can join groups

### DIFF
--- a/charter/README.md
+++ b/charter/README.md
@@ -42,9 +42,38 @@ These are our core values, as voted by the maintainers, in order of importance. 
 ## Participation
 
  * [Code of Conduct](../CODE_OF_CONDUCT.md)
+ * [Joining](#joining_governance)
  * [Using Slack](https://github.com/electron/governance/blob/master/policy/slack.md)
  * [Triaging Issues](https://github.com/electron/governance/blob/master/playbooks/README.md)
 <!-- * [Using Pull Requests](FIXME: link to PR etiquette doc) -->
+
+### Joining
+
+Thank you for wanting to contribute to Electron!
+
+If you're not already on the Electron Slack, please sign this
+[Code of Conduct form](https://electronjs.org/maintainers/join).
+The [Community and Safety Working Group](../wg-community-safety) will
+process your application and, if everything is alright, you'll be given
+guest access to Electron's Slack.
+
+To join a [Working Group](README.md#working-groups), you should contact
+an existing member of the group on Electron's Slack about how to join.
+Requirements differ from group to group &ndash; for example,
+[Security](../wg-security) has stricter [rules](../wg-security/membership-and-notifications.md#membership)
+by necessity &ndash; but you're generally expected to show participation
+becoming a full member:
+
+ * Actively contribute to the Working Group's work
+ * Attend 3 out of 6 consecutive meetings
+ * Notify `@community-safety-wg` in Slack about your intent to join _if_
+   you're not already in a Working Group. One benefit of joining a Group
+   is becoming a [maintainer](README.md#definitions), and maintainer
+   membership is handled by C&S.
+
+Once you've done all these things, notify the Working Group and it will decide
+on your membership. This generally involves a vote by existing members, but each
+group has its own process.
 
 ## Working Groups
 


### PR DESCRIPTION
Our project had an influx of new maintainers after the NYC summit :tada: This is the first time we've had an influx since governance was introduced, and there was room for improvement:

1. Some new volunteers were unsure how to join a Working Group.
1. Some [maintainers](https://github.com/electron/governance/#definitions) were unsure about any process around bringing new volunteers into a Working Group.
1. Most Working Groups don't outline requirements for group membership.
1. C&S's role in overseeing maintainer membership caused some delay in people joining.

This PR tries to address these by:

1. Showing the clear steps a new volunteer can follow to join Slack and/or governance
1. Setting a baseline for participation expectations
1. Placing the C&S notification responsibility on the applicant, so that it is part of the process and can happen in parallel with the other participation requirements, reducing any delay