### PR TITLE
Add API WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,27 @@ The Electron governance system is comprised of Working Groups that oversee diffe
 |                                                                            |
 |                               WORKING GROUPS                               |
 | +----------------------+ +----------------------+ +----------------------+ |
-| |        Security      | |       Outreach       | |       Upgrades       | |
+| |         API          | |  Community & Safety  | |       Ecosystem      | |
 | +----------------------+ +----------------------+ +----------------------+ |
 | +----------------------+ +----------------------+ +----------------------+ |
-| |       Ecosystem      | |  Community & Safety  | |       Releases       | |
+| |       Outreach       | |       Releases       | |       Security       | |
 | +----------------------+ +----------------------+ +----------------------+ |
+|                          +----------------------+                          |
+|                          |       Upgrades       |                          |
+|                          +----------------------+                          |
 +----------------------------------------------------------------------------+
 ```
 
+* [API WG](wg-api)
+  * [Overview](wg-api/README.md)
+  * [Meeting Notes](wg-api/meeting-notes)
+* [Community & Safety WG](wg-community-safety)
+  * [Overview](wg-community-safety/README.md)
+  * [Meeting Notes](wg-community-safety/meeting-notes)
+* [Ecosystem WG](wg-ecosystem)
+  * [Overview](wg-ecosystem/README.md)
+  * [Associated Repositories](wg-ecosystem/repos.md)
+  * [Meeting Notes](wg-ecosystem/meeting-notes)
 * [Outreach WG](wg-outreach)
   * [Overview](wg-outreach/README.md)
   * [Meeting Notes](wg-outreach/meeting-notes)
@@ -27,20 +40,13 @@ The Electron governance system is comprised of Working Groups that oversee diffe
   * [Overview](wg-releases/README.md)
   * [Associated Repositories](wg-releases/repos.md)
   * [Meeting Notes](wg-releases/meetig-notes)
+* [Security WG](wg-security)
+  * [Overview](wg-security/README.md)
+  * [Meeting Notes](wg-security/meeting-notes)
 * [Upgrades WG](wg-upgrades)
   * [Overview](wg-upgrades/README.md)
   * [Associated Repositories](wg-upgrades/repos.md)
   * [Meeting Notes](wg-upgrades/meeting-notes)
-* [Ecosystem WG](wg-ecosystem)
-  * [Overview](wg-ecosystem/README.md)
-  * [Associated Repositories](wg-ecosystem/repos.md)
-  * [Meeting Notes](wg-ecosystem/meeting-notes)
-* [Community & Safety WG](wg-community-safety)
-  * [Overview](wg-community-safety/README.md)
-  * [Meeting Notes](wg-community-safety/meeting-notes)
-* [Security WG](wg-security)
-  * [Overview](wg-security/README.md)
-  * [Meeting Notes](wg-security/meeting-notes)
 * [Administrative WG](wg-administrative)
 
 ## Definitions

--- a/wg-api/README.md
+++ b/wg-api/README.md
@@ -1,0 +1,73 @@
+# API WG
+
+Oversees public API design based on project principles.
+
+## Membership
+
+| Avatar | Name | Role | Time Zone |
+| -------------------------------------------|----------------------|----------------------------| -------- |
+| <img src="https://github.com/codebytere.png" width=100 alt="@codebytere">  | Shelley Vohr [@codebytere](https://github.com/codebytere) | **Chair** | PT (San Francisco) |
+| <img src="https://github.com/loc.png" width=100 alt="@loc">  | Andy Locascio [@loc](https://github.com/loc) | Member | PT (San Francisco) |
+| <img src="https://github.com/ckerr.png" width=100 alt="@ckerr">  | Charles Kerr [@ckerr](https://github.com/ckerr) | Member | CT (New Orleans) |
+| <img src="https://github.com/erikmellum.png" width=100 alt="@erikmellum">  | Erik Mellum [@erikmellum](https://github.com/erikmellum) | Member | PT (Chico) |
+| <img src="https://github.com/nornagon.png" width=100 alt="@nornagon">  | Jeremy Apthorp [@nornagon](https://github.com/nornagon) | Member | PT (San Francisco) |
+| <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | ET (Harrisburg) |
+| <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
+| <img src="https://github.com/miniak.png" width=100 alt="@miniak">  | Milan Burda [@miniak](https://github.com/miniak) | Member | CET (Prague) |
+| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | **Chair** | PT (Vancouver) |
+| <img src="https://github.com/itsananderson.png" width=100 alt="@itsananderson">  | Will Anderson [@itsananderson](https://github.com/itsananderson) | Member | PT (Seattle) |
+
+## Areas of Responsibility
+
+* Review and unblocks API PRs in a timely way.
+* Resolve API disagreements.
+* Define the process for which API changes are reviewed and approved.
+* Create initiatives to develop/modify/change API implementations.
+* Increase participation with web standards groups.
+
+## Changing API
+
+1. Contributors should follow the [best practices guide](./best-practices.md) when applicable.
+1. When creating change issues / PRs, contributors should mention `@wg-api` in the description and request review from `wg-api`.
+1. WG members should watch for these notifications and give review in a timely manner.
+1. Ideally, this will be enough! :rocket:
+
+If consensus isn't reached on a PR, an interested party should add the PR's URL to the WG's next meeting agenda:
+
+* If the PR needs reviewers, the WG will find volunteers to review.
+* If the PR needs consensus, the WG will resolve the issue by majority vote. Votes should be made in consideration of the [best practices guide](./best-practices.md).
+* WG members should read the meeting agenda _in advance_ to be able to unblock PRs in a well-informed way.
+* Members unable to attend a meeting's vote may submit their vote to the Chair prior to the meeting.
+
+## Associated Repositories
+
+* `electron/electron`
+
+## Meeting Schedule
+
+* Biweekly Rotating Times:
+  * 5 PM PT monthly [calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=MGdmdmxudG9vOXFianFmcHM3NDBiN2trMzhfMjAxOTEwMDhUMDAwMDAwWiBjYzM3dmx1c2w2Z3Y2dnVvbjhrZGNqYzc3a0Bn&tmsrc=cc37vlusl6gv6vuon8kdcjc77k%40group.calendar.google.com&scp=ALL)
+  * 9 AM PT monthly + offset [calendar](https://calendar.google.com/event?action=TEMPLATE&tmeid=MWdqdmZiZ2RoY3FxNDg5M3BlN2c1cDg0bnBfMjAxOTA5MjZUMTYzMDAwWiBjYzM3dmx1c2w2Z3Y2dnVvbjhrZGNqYzc3a0Bn&tmsrc=cc37vlusl6gv6vuon8kdcjc77k%40group.calendar.google.com&scp=ALL)
+
+Meeting notes may be viewed in [meeting-notes](meeting-notes).
+
+## Joining the API WG
+
+In order to become formal members of the WG, prospective members must:
+
+1. be actively contributing to the work of the WG,
+1. attend 2 out of 4 consecutive meetings, and
+1. be approved by a 2/3rds majority of current WG members (rounded up).
+    1. The prospective member shall leave the meeting during the deliberation and vote.
+    1. The meeting notes shall contain only the outcome of the vote (approved/not approved), not the individual votes.
+    1. Members not able to attend the meeting at which the vote occurs may submit their vote to the Chair prior to the meeting.
+
+If you're interested in joining the API Working Group, reach out to an [existing member](#Membership) and ask to be invited to the regular meeting and as a guest to the #wg-api channel in Slack.
+
+### Actively contributing
+
+"Actively contributing" doesn't necessarily mean writing code. It does mean that you should be in regular communication with the API WG (including attending meetings), and it does mean that you should be materially contributing to the project in some way. If you're not sure whether the work you're doing counts as "materially contributing", reach out to a [member](#Membership) and ask. 🙂
+
+### Timezones
+
+The API WG currently meets at alternating times to accommodate the timezone constraints of the members.

--- a/wg-api/README.md
+++ b/wg-api/README.md
@@ -14,30 +14,14 @@ Oversees public API design based on project principles.
 | <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | ET (Harrisburg) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
 | <img src="https://github.com/miniak.png" width=100 alt="@miniak">  | Milan Burda [@miniak](https://github.com/miniak) | Member | CET (Prague) |
-| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | **Chair** | PT (Vancouver) |
+| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |
 | <img src="https://github.com/itsananderson.png" width=100 alt="@itsananderson">  | Will Anderson [@itsananderson](https://github.com/itsananderson) | Member | PT (Seattle) |
 
 ## Areas of Responsibility
 
-* Review and unblocks API PRs in a timely way.
-* Resolve API disagreements.
 * Define the process for which API changes are reviewed and approved.
 * Create initiatives to develop/modify/change API implementations.
 * Increase participation with web standards groups.
-
-## Changing API
-
-1. Contributors should follow the [best practices guide](./best-practices.md) when applicable.
-1. When creating change issues / PRs, contributors should mention `@wg-api` in the description and request review from `wg-api`.
-1. WG members should watch for these notifications and give review in a timely manner.
-1. Ideally, this will be enough! :rocket:
-
-If consensus isn't reached on a PR, an interested party should add the PR's URL to the WG's next meeting agenda:
-
-* If the PR needs reviewers, the WG will find volunteers to review.
-* If the PR needs consensus, the WG will resolve the issue by majority vote. Votes should be made in consideration of the [best practices guide](./best-practices.md).
-* WG members should read the meeting agenda _in advance_ to be able to unblock PRs in a well-informed way.
-* Members unable to attend a meeting's vote may submit their vote to the Chair prior to the meeting.
 
 ## Associated Repositories
 

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -1,0 +1,4 @@
+# Public API Best Practices
+
+This is a placeholder for a document being drafted by @zcbenz.
+It will be added in a separate PR.

--- a/wg-api/meeting-notes/2019-09-26.md
+++ b/wg-api/meeting-notes/2019-09-26.md
@@ -1,0 +1,41 @@
+# Date: 2019-09-26
+
+[Post Summit Notes](https://hackmd.io/LRROdqolSg2jTXHuXHumRA?edit)
+
+## Attendees
+
+**Members:**
+
+* @ckerr
+* @codebytere
+* @emellum
+* @itsananderson
+* @jkleinsc
+* @keeleyhammond
+* @loc
+* @marshallofsound
+* @miniak
+* @nornagon
+
+**Visitors:**
+
+## Agenda
+
+Housekeeping checklist:
+
+- [x] Slack
+  - [x] add Slack channel in ElectronHQ workspace
+  - [x] make Slack user-group in ElectronHQ workspace
+  - [x] Calendar
+    - [x] add GitHub team in Electron
+    - [x] Add those volunteers whose emails are known (@MarshallOfSound)
+  - [ ] Governance repo (@ckerr)
+    - [ ] Add directory for wg-api in [governance repo](https://github.com/electron/governance)
+    - [ ] add README in wg-api directory
+
+## Followup Discussion
+
+## Agenda for Next Meeting
+
+- [ ] Find Work volunteers
+

--- a/wg-api/meeting-notes/2019-10-07.md
+++ b/wg-api/meeting-notes/2019-10-07.md
@@ -1,0 +1,47 @@
+# API Working Group
+
+### Date: 2019-10-07
+
+Post Summit: https://hackmd.io/LRROdqolSg2jTXHuXHumRA?edit
+
+## Attendees:
+
+**Members:**
+ @ckerr
+ @jkleinsc
+ @zcbenz
+
+**Visitors:**
+ @groundwater
+
+## Agenda:
+
+* Housekeeping checklist:
+    - [x] Slack
+      - [x] add Slack channel in ElectronHQ workspace
+      - [x] make Slack user-group in ElectronHQ workspace
+    - [x] add GitHub team in Electron
+    - [x] Calendar
+      - [x] Add those volunteers whose emails are known (@MarshallOfSound)
+    - [x] Governance repo (@ckerr)
+      - [x] Add directory for wg-api in [governance repo](https://github.com/electron/governance)
+      - [x] add README in wg-api directory
+      - [x] Add wg-api in top-level [README in governance repo](https://github.com/electron/governance/blob/master/README.md)
+    - [x] Process draft (@ckerr)
+    - [ ] Style Guide Rough Draft (@zcbenz)
+
+## Follow-up Discussion:
+
+## Agenda for Next Meeting
+ - [ ] Create the list of members
+    * @ckerr
+    * @codebytere (chair)
+    * @emellum
+    * @itsananderson
+    * @jkleinsc
+    * @keeleyhammond
+    * @loc
+    * @marshallofsound
+    * @miniak
+    * @nornagon
+ - [ ] Find Work volunteers


### PR DESCRIPTION
Does what it says on the tin.

In this PR I've tried to use:
 * The mission, as I understood it, that was decided in the first meetings
 * The member list from people who signed up in the first meetings
 * Membership vote / meeting time boilerplate from wg-upgrades
 * Outlined a "Change Procedure" that proritizes unblocking things async to avoid excess meetings / process-for-process'-sake
 * Created an agenda section for changes-that-need-unblocking modeled on wg-releases' agenda section for PRs-that-need-backporting

IMO this borrows good practices from other workgroups but I'm not going to claim this is the One True Way. Reviews and suggestions are welcomed!
