### PR TITLE
fix: typos in Ecosystem WG docs

### DIFF
--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -57,7 +57,7 @@ These projects are sorted alphabetically, their order does not reflect that any 
   * Forge
   * Spectron
 
-...and all other tools third party community based Electron tools.
+...and all other third party community based Electron tools.
 
 ## Associated Repositories
 
@@ -109,4 +109,4 @@ Meeting notes may be viewed in [meeting-notes](meeting-notes).
 
 ## Membership
 
-Prospective new members should reach out to an existing member to ask to be invited to the regular meetings and to be added as a Slack guest to #wg-docs-and-tools. That person may be added to the working group by a 2/3rds vote of WG members at a WG meeting. The prospective member should leave the meeting while the deliberation & vote is underway, and be informed only of the outcome of the vote (approved/not approved).
+Prospective new members should reach out to an existing member to ask to be invited to the regular meetings and to be added as a Slack guest to #wg-ecosystem. That person may be added to the working group by a 2/3rds vote of WG members at a WG meeting. The prospective member should leave the meeting while the deliberation & vote is underway, and be informed only of the outcome of the vote (approved/not approved).


### PR DESCRIPTION
Fix Slack channel name and removed an extra word.