### PR TITLE
docs: add 10/24 API WG notes

### DIFF
--- a/wg-api/meeting-notes/2019-10-24.md
+++ b/wg-api/meeting-notes/2019-10-24.md
@@ -1,0 +1,67 @@
+# API Working Group
+
+## Date: 2019-10-24
+
+### Attendees
+
+**Members:**
+
+* @nornagon
+* @codebytere
+* @miniak
+* @ckerr
+* @marshallofsound
+* @keeleyhammond
+* @willanderson
+
+**Visitors:**
+
+None
+
+### Agenda
+
+- delete `<webview>.getWebContents()`?
+    - @miniak had a PR to deprecate this and move it to the remote module [#17201](https://github.com/electron/electron/pull/17201), resurrected as [#20726](https://github.com/electron/electron/pull/20726)
+    - something like `remote.webContentsFromId(webview.webContentsId)` (we already have undocumented `remote.getGuestWebContents()`)
+    - how can users check that the webview belongs to a given page (if you send `webview.webContentsId` to the main process)?
+    - what are current usages? - context menu, others?
+    - when we deprecate, we should note how to replace it
+    - no dissent for deprecating & removing
+- move remote to electron-userland?
+    - can't use process.electronBinding from sandboxed processes
+    - bad to depend on electronBinding from 3rd-party modules
+    - v8 WeakRef would let us drop a lot of the remote-specific native code
+    - is there a race condition that requires synchronous IPC during GC?
+- [#20682](https://github.com/electron/electron/pull/20682) - feat: split shell.openItem into sync and async
+- Renderer-to-renderer communication
+    - @nornagon experimenting with using MessagePorts for this
+    - @codebytere mentions that Node has its own MessagePort thing for workers
+- [#20648](https://github.com/electron/electron/pull/20648) - feat: allow multi language spellcheckprovider
+    - breaking change, which does not allow feature detection as the method / callback arguments change **discuss next time**
+- Should we have these meetings every week?
+  - We ran out of time and there's lots of stuff to talk about.
+    - Undecided
+
+- How are we speccing out potential changes?
+- Design doc
+- Consensus?
+    - opt-in process
+    - tool for resolving concerns when needed
+- Recording history of discussion
+
+### Action Items
+
+@codebytere will start on design doc process work.
+
+### Follow-up Discussion
+
+None.
+
+### Unblock Requests
+
+None.
+
+### Agenda for Next Meeting
+
+Getter/Setter Properties vs Functions.
+


### PR DESCRIPTION
Adds notes for today's API WG meeting.

cc @electron/wg-api 