### PR TITLE
doc: add spec-proposal process docs

### DIFF
--- a/wg-api/design-spec-process.md
+++ b/wg-api/design-spec-process.md
@@ -1,0 +1,25 @@
+# API Spec Process
+
+## What Is This Used For?
+
+The API Working Group should function as a clear escalation path towards resolving differing perspectives for the following API changes:
+* A new API
+* An API removal with replacement
+* An API deprecation and removal with no replacement
+* A change semantics of an existing API.
+
+This process is not intended to require documents for all changes under the following categories; if there is agreement amongst maintainers and no strong objections to a change than this process should not be invoked.
+
+## What Is The Process?
+
+For API changes falling under the categories above and for which no consensus can be reached, a spec document should be written.
+
+This document has no minimum length and can thus be short be short, but should cover all basic information outlined in the [`api-spec-template`](spec-documents/api-spec-template.md).
+
+This document will be able to provide rationale for the choice as well as preserve considerations and allow the WG to more easily ratify a specific approach.
+
+## Ratifying Spec Change Proposals
+
+Once this document has been written, it should be placed on the API Working Group's agenda for a given meetings, where the group will discuss and vote with sufficient consensus to move forward with one of the proposed solutions in a given design document.
+
+Once a proposal has been ratified, it will be PRed into the [`spec-documents`](TBD) directory to allow external community members to better understand the process behind the technical decision that was made.

--- a/wg-api/spec-documents/api-spec-template.md
+++ b/wg-api/spec-documents/api-spec-template.md
@@ -1,0 +1,16 @@
+# API Spec Template
+
+## Summary
+<!--- 1-3 sentence description of what is changing and why. --->
+
+## Platforms
+<!--- What platforms will be affected? Options include macOS, Windows, Linux, or any combination thereof. --->
+
+## Impetus
+<!--- What is prompting this change? A bug, user feedback, or something else? If there is a bug, please link it. --->
+
+## API Design
+<!--- Discuss any background and motivation not already in the summary above. Give implementation details. What options are under consideration, and what is your preferred solution or approach? --->
+
+## Rollout Plan
+<!--- What branches do you ultimately want this API to live in? If this change would require a minor release, please justify the reason for that request. -->


### PR DESCRIPTION
This is an initial spike for a document design process overseen by the API Working Group. None of this has been decided upon and all can change; this is simply to start this work into motion and encourage discussion and feedback.

cc @electron/wg-api 