### PR TITLE
docs: update Ecosystem WG key results

### DIFF
--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -24,8 +24,8 @@ Oversees the projects that make Electron app development easier.
 As a newcomer or experienced app developer, you can use Electron’s tooling and documentation to build your app well.
 
 **Key Results:**
-* Increase adoption of Electron-provided tooling.
-* Decrease percentage of documented poor-practices
+
+* Increase adoption of Electron-provided tooling
 * Increase views on https://electronjs.org/docs
 
 ## Areas of Responsibility


### PR DESCRIPTION
In the [10/31 :jack_o_lantern: meeting](https://github.com/electron/governance/blob/master/wg-ecosystem/meeting-notes/2019-10-31.md), the Ecosystem WG discussed how to measure the key result "decrease percentage of documented poor-practices". We found that it's difficult to measure differently than the other key result, "increase views on /docs", particularly if the scope is "just our docs". The consensus was to merge the two mentioned KRs together, and this PR is the output item for that.