### PR TITLE
docs: add meeting notes from 2020-01-13

### DIFF
--- a/wg-api/meeting-notes/2020-01-13.md
+++ b/wg-api/meeting-notes/2020-01-13.md
@@ -1,0 +1,36 @@
+# API Working Group
+
+## Date: 2020-01-13
+
+### Attendees
+
+**Members:**
+
+* @codebytere
+* @zcbenz
+* @marshallofsound
+* @nornagon
+* @loc
+* @itsananderson
+
+### Followup
+
+* Where did our previous discussions from the 2019-11-18 meeting land? Did anyone take notes?
+  * Let's re-discuss the shortcuts proposal? [globalShortcuts => shortcuts](https://github.com/electron/electron/issues/20964)
+  * What's the motivation?
+  * Is this technically feasible?
+  * There's a 3rd-party module that does this, but poorly (electron-localshort)
+    * [electron-localshortcut](https://github.com/parro-it/electron-localshortcut)
+
+### Agenda
+
+* [//extensions API](https://github.com/electron/electron/issues/19447#issuecomment-514848721)— NB, none of this is available in any release, and won't be until //extensions is stable & working. But we should still talk about this draft API!
+  * Consider pushing it to `session.extensions.loadExtension` / etc.
+  * What happens if you load the same extension twice? Potentially w/ a different version?
+  * Load extensions from ASAR?
+  * What extensions should we test with?
+    * https://www.npmjs.com/package/electron-devtools-installer#what-extensions-can-i-use
+
+## Action Items
+
+* **@codebytere** to follow up with @poiru with questions about shortcuts proposal.


### PR DESCRIPTION
Add meeting notes from yesterday's API WG meeting.

cc @wg-api