### PR TITLE
chore: add chromedriver to Releases AORs

### DIFF
--- a/wg-releases/repos.md
+++ b/wg-releases/repos.md
@@ -7,3 +7,4 @@
 - [`electron/cation`](https://github.com/electron/cation)
 - [`electron/clerk`](https://github.com/electron/clerk)
 - [`electron/unreleased`](https://github.com/electron/unreleased)
+- [`electron/chromedriver`](https://github.com/electron/chromedriver)


### PR DESCRIPTION
What it says on the tin.

cc @electron/wg-releases 