### PR TITLE
docs: fix meeting time for Ecosystem WG

### DIFF
--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -101,7 +101,7 @@ These repos are sorted alphabetically, their order does not reflect that any of 
 
 ## Meeting Schedule
 
-**Sync Meeting** 30min every other Thursday @ [16:00 UTC](https://duckduckgo.com/?q=16%3A00+UTC&ia=answer)
+**Sync Meeting** 30min every other Thursday @ [17:00 UTC](https://duckduckgo.com/?q=17%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).
 


### PR DESCRIPTION
This might have been a Daylight Savings thing, but it seems like the UTC time of our meetings is off. We meet at 9:00 AM PT, which is 5:00 PM UTC.