### PR TITLE
docs: remove @erikmellum from outreach wg

### DIFF
--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -11,7 +11,6 @@ Grows the Electron community
 | <img src="https://github.com/jdalton.png" width=100 alt="@jdalton">  | John-David Dalton [@jdalton](https://github.com/jdalton) | Member | PT (Seattle) |
 | <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |
 | <img src="https://github.com/bnb.png" width=100 alt="@bnb">  | Tierney Cyren [@bnb](https://github.com/bnb) | Member | ET (New York City) |
-| <img src="https://github.com/erikmellum.png" width=100 alt="@erikmellum">  | Erik Mellum [@erikmellum](https://github.com/erikmellum) | Member | PT (Chico) |
 | <img src="https://github.com/erickzhao.png" width=100 alt="@erickzhao">  | Erick Zhao [@erickzhao](https://github.com/erickzhao) | Member | PT (Vancouver) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
 


### PR DESCRIPTION
Removing Erik as he has not been active since joining Outreach WG.