### PR TITLE
docs: add 2020-03-23 wg-api meeting notes

### DIFF
--- a/wg-api/meeting-notes/2020-03-23.md
+++ b/wg-api/meeting-notes/2020-03-23.md
@@ -1,0 +1,73 @@
+# API Working Group
+
+## Date 3/23/19
+
+### Attendees
+
+* @codebytere 
+* @nornagon 
+* @MarshallOfSound 
+* @itsananderson
+* @VerteDinde
+* @loc
+* @jkleinsc 
+
+### Followup
+
+- **DONE** @codebytere to de-deprecate existing properties deprecations
+- **DONE** @zcbenz to update best practices API doc
+
+### Agenda
+
+- Chair rotation
+    - postponed until next meeting
+- https://github.com/electron/electron/pull/20006
+    - Closed due to inactivity.
+    - If there's renewed interest we could reconsider.
+    - Generally we're trying to avoid breaking APIs without v good reason
+- [feat: add APIs for accessing NSUserDefaults in the given domain](https://github.com/electron/electron/pull/22193)
+    - **Verdict**: We will NOT accept this PR.
+        - Not accessible from MAS
+        - Not possible to subscribe to changes, which might encourage polling
+        - Can be implemented straightforwardly as a native module.
+- https://github.com/electron/electron/pull/22701
+    - **Verdict:** We want this feature, pending details of the API.
+        - Use cases include support calls & automated testing
+    - Should this be exposed on desktopCapturer or somewhere else?
+            - `WebContents.getStream`..?
+        - Then you could send it to a different renderer
+    - @loc and @MarshallOfSound to review in detail
+- https://github.com/electron/electron/pull/22774
+    - **Verdict:** This needs more experimentation to determine if a better interface is possible.
+    - `contextBridge` simple objects/functions
+    - Costly to send large objects over the bridge
+        - e.g. redux state
+        - on the order of 10ms
+    - V8 serializer is much faster for serializable objects
+    - Going to try some benchmarks to see if we can work around it without an API change.
+- https://github.com/electron/governance/pull/232
+    - **Verdict:** Approved given backwards compatibility
+    - This a breaking change
+    - It could be redone to be backwards-compatible
+    - Reduce inconsistency
+    - Let's not break old code if we can avoid it!
+- https://github.com/electron/governance/pull/254
+    - **Verdict:** Agreed to experiment.
+    - Exposes `//ui/views`
+    - Use cases:
+        - splash screen
+        - placeholder background
+        - simple "utility" windows e.g. screensharing
+        - switch between multiple WebContentsViews (e.g. tabs)
+    - This should be marked EXPERIMENTAL
+    - WebContentsView should take WebPreferences rather than taking a WebContents
+    - What happens if you add a View to multiple parents?
+    - Could these use cases be addressed by adding a backgroundImage option to BrowserWindow?
+        - Yes, but we're hoping to see some more imaginative real-world use cases
+
+## Action Items
+
+- @MarshallOfSound to clarify on what experimental means in the docs
+- @codebytere to research Chromium's Intent to Implement / Intent to Experiment protocols
+- @zcbenz to make some revisions to the Views spec PR
+- @loc and @MarshallOfSound to review "get tab media stream" PR


### PR DESCRIPTION
Notes from today's meeting.

cc @electron/wg-api 