### PR TITLE
docs: Ecosystem WG 2020-04-30 minutes

### DIFF
--- a/wg-ecosystem/meeting-notes/2020-04-30.md
+++ b/wg-ecosystem/meeting-notes/2020-04-30.md
@@ -2,8 +2,6 @@
 
 Thursday, Apr 30, 2020 (9:00-10:00am PT)
 
-https://meet.google.com/wos-agzb-byz
-
 ## Attendees
 - @erickzhao
 - @felixrieseberg

--- a/wg-ecosystem/meeting-notes/2020-04-30.md
+++ b/wg-ecosystem/meeting-notes/2020-04-30.md
@@ -1,0 +1,55 @@
+# Ecosystem WG meeting 2020-04-30
+
+Thursday, Apr 30, 2020 (9:00-10:00am PT)
+
+https://meet.google.com/wos-agzb-byz
+
+## Attendees
+- @erickzhao
+- @felixrieseberg
+- @HashimotoYT
+- @malept
+- @MarshallOfSound 
+
+## Agenda
+
+### Follow-up
+* Results of async votes from last week
+    * [Admin WG membership change](https://github.com/electron/governance/pull/262): **Passed**
+    * [Chair Rotation](https://github.com/electron/governance/pull/276): **Passed**
+* Documenting TypeScript breaking changes ([Context](https://github.com/electron/electron/pull/23054#discussion_r406394398))
+    * **Conclusion**: @MarshallOfSound gave feedback to @zcbenz earlier over Slack. PR should be good after the changes.
+* Appzi for electronjs.org feedback
+    * [Appzi in action](https://github.com/electron/electronjs.org/pull/3852)
+    * i18n: not available yet
+    * GDPR: they apparently don't collect mandatory cookies?
+    * **Conclusion**: Let's ship to English versions of the website.
+
+### New Items
+* Migrating `hubdown` to the `docs` org ([Context](https://github.com/electron/governance/issues/164)) (@zeke)
+    * @zeke was not able to attend meeting, but his team at GitHub is still willing to push this forward.
+    * We're okay with moving it over since it's not a direct or transitive dependency for electronjs.org.
+    * Sticking point: we'd like whoever owns the project to use our CFA solution.
+    * **Conclusion**: If the docs team at GitHub is good with CFA, we'll transfer `electron/hubdown` over.
+* Key Results: should these longer-term goals need updating? (@erickzhao)
+    * **Conclusion**: We've decided to come up with goals for the WG asynchronously, and discuss them next meeting.
+<!--   * Increase adoption of Electron-provided tooling (@ckerr)
+  * Increase views on /docs (@felix) -->
+  
+### Issue Tracker Triage
+* [Open pull requests for the WG to review](https://github.com/pulls?q=is%3Apr+team-review-requested%3Aelectron%2Fwg-ecosystem+archived%3Afalse+is%3Aopen+)
+    * [fix: retry upload failures (electron-notarize#37)](https://github.com/electron/electron-notarize/pull/37) -- What are the different exit codes? Is it safe to retry whenever the exit code isn't 0?
+        * **Conclusion**: Reject the PR. @MarshallOfSound will post about it in the PR.
+* [Open pull requests mentioning the WG in a comment](https://github.com/pulls?q=is%3Apr+team%3Aelectron%2Fwg-ecosystem+archived%3Afalse+is%3Aopen)
+* [Open issues on `electron/electron` specifically for documentation](https://github.com/electron/electron/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22documentation+%3Anotebook%3A%22+)
+* [Open pull requests on `electron/electron` specifically for documentation](https://github.com/electron/electron/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aopen+%22docs%22+in%3Atitle)
+    * [docs: event.newGuest for new-window in WebContents and webContents in BrowsweWindow's constructor (#21698)](https://github.com/electron/electron/pull/21698)
+        * **Conclusion**: Accepted.
+    * [docs: update contextIsolation documentation on access to globals (#19732)](https://github.com/electron/electron/pull/19732)
+        * **Conclusion**: Comments were addressed, but the PR now conflicts with `master`. @MarshallOfSound will ask Shiranka to rebase it.
+
+## Action Items
+* @erickzhao will gate Appzi behind English versions of electronjs.org.
+* @MarshallOfSound will talk to @zeke about setting up CFA for `hubdown`.
+* @everyone will post potential Ecosystem WG goals from last quarter.
+* @MarshallOfSound will talk to @samiskin about rebasing #19732.

--- a/wg-ecosystem/meeting-notes/2020-04-30.md
+++ b/wg-ecosystem/meeting-notes/2020-04-30.md
@@ -51,5 +51,5 @@ https://meet.google.com/wos-agzb-byz
 ## Action Items
 * @erickzhao will gate Appzi behind English versions of electronjs.org.
 * @MarshallOfSound will talk to @zeke about setting up CFA for `hubdown`.
-* @everyone will post potential Ecosystem WG goals from last quarter.
+* @everyone will post potential Ecosystem WG goals for the near future.
 * @MarshallOfSound will talk to @samiskin about rebasing #19732.


### PR DESCRIPTION
Items to follow up on for next meeting:
* @erickzhao will gate Appzi behind English versions of electronjs.org.
* @MarshallOfSound will talk to @zeke about setting up CFA for `hubdown` to move it to GitHub's Product Documentation team.
* @electron/wg-ecosystem will brainstorm potential goals for the near future.
* @MarshallOfSound will remind @samiskin about rebasing electron/electron#19732.