### PR TITLE
feat: add 2020-04-29 releases notes

### DIFF
--- a/wg-releases/meeting-notes/2020-04-29.md
+++ b/wg-releases/meeting-notes/2020-04-29.md
@@ -1,0 +1,29 @@
+# Releases WG
+
+### Date: 2020-04-29
+
+**Members**
+
+* @codebytere 
+* @ckerr
+* @deepak1556
+* @jkleinsc 
+* @MarshallOfSound
+* @sofianguy
+* @zcbenz
+
+**Visitors**
+* @VerteDinde
+
+## Agenda
+
+* Discuss todo items as we approach v9 stable
+
+## Backport Requests
+
+* [Pending votes](https://github.com/electron/electron/pulls?q=is%3Apr+is%3Aopen+label%3A%22pending-vote+🗳%22)
+
+## Action Items
+
+## Follow-Up Discussion
+


### PR DESCRIPTION
There weren't many notes, but I didn't want to just delete them before adding new notes for today's meeting :slightly_smiling_face: 

cc @electron/wg-releases 