### PR TITLE
docs: Outreach WG April 27, 2020 minutes

### DIFF
--- a/wg-outreach/meeting-notes/2020-04-27.md
+++ b/wg-outreach/meeting-notes/2020-04-27.md
@@ -1,0 +1,29 @@
+# Outreach Working Group
+Date: April 27, 2020
+
+## Attendees
+**Members:**
+* @cruzerld 
+* @erickzhao 
+* @felixrieseberg
+* @MarshallOfSound 
+* @vertedinde
+
+**Visitors:**
+* None
+
+
+## Agenda
+* OpenJS Case Studies (@felixrieseberg)
+    * Keeley taking those over, speaking with Rachel
+* /r/electronjs Subreddit
+    * @erickzhao joined the moderation team! @MarshallOfSound  also on moderation team
+    * Currently monitoring; can make improvements
+        * Use sidebar to include helpful links
+        * Update CSS
+        * Make sticky posts with resources
+
+## Action Items
+* @felixrieseberg will fix the electronjs.org homepage (along with adding app screenshots).
+    * PR is open, a couple small changes to made before merging
+* Switching Twitter account email - @bnb following up with Shelley/Jacob.


### PR DESCRIPTION
Adds the notes from the Outreach WG for April 27, 2020