### PR TITLE
docs: tweak the needs repro message

### DIFF
--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -1,3 +1,5 @@
+## If No Repro Included
+
 Thank you for taking the time to report this issue and helping to make Electron better.
 
 Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself?
@@ -7,3 +9,18 @@ Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's
 I'm adding the `blocked/needs-repro` label for this reason. After you've responded, please link to the test case and @ me in a followup comment.
 
 Thanks in advance! Your help is appreciated.
+
+## If Repro Requires Third-Party Tooling
+
+Thank you for taking the time to report this issue and helping to make Electron better.
+
+Researching issues that require triaging third-party code is usually not feasable due to the high volume of issues that are reported to Electron.
+Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself without third-party code?
+
+Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
+
+I'm adding the `blocked/needs-repro` label for this reason. After you've responded, please link to the test case and @ me in a followup comment.
+
+Thanks in advance! Your help is appreciated.
+
+

--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -2,7 +2,7 @@ Thank you for taking the time to report this issue and helping to make Electron 
 
 Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself?
 
-Standalone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unneccessary variables from the equation, and it can also provide the basis for automated regression tests.
+Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
 I'm adding the `blocked/needs-repro` label for this reason. After you've responded, please link to the test case and @ me in a followup comment.
 


### PR DESCRIPTION
1. Fix a typo in the "needs repro" message

2. Add a variant that addresses the case when a repro is available but is impractical because it has dependencies that would require us to spelunk a lot of third-party code