### PR TITLE
docs: add 9/2 Release WG notes

### DIFF
--- a/wg-releases/meeting-notes/2020-07-29.md
+++ b/wg-releases/meeting-notes/2020-07-29.md
@@ -18,7 +18,6 @@
 ## Backport Requests
 
 * [Pending votes](https://github.com/electron/electron/pulls?q=is%3Apr+is%3Aopen+label%3A%22backport%2Frequested+%F0%9F%97%B3%22+)
-
 * [#24711](https://github.com/electron/electron/pull/24711) - feat: add worldSafe flag for executeJS results 
     * **Verdict:** Approved
 * [#24712](https://github.com/electron/electron/pull/24712) - feat: add worldSafe flag for executeJS results

--- a/wg-releases/meeting-notes/2020-08-05.md
+++ b/wg-releases/meeting-notes/2020-08-05.md
@@ -15,7 +15,8 @@
 **Visitors**
 
 ## Agenda
-* 10-x-y check in and upcoming schedule
+
+* `10-x-y` check in and upcoming schedule
 
 ## Backport Requests
 
@@ -23,8 +24,8 @@
 
 ## Action Items
 
-* none
+None.
  
 ## Follow-Up Discussion
 
-* none
+None.

--- a/wg-releases/meeting-notes/2020-08-19.md
+++ b/wg-releases/meeting-notes/2020-08-19.md
@@ -14,6 +14,7 @@
 **Visitors**
 
 ## Agenda
+
 * 10.0.0 check in
 * Node.js version for Electron 11?
     * This will be v12 - it's a quiet release
@@ -38,3 +39,5 @@
 * Stable Prep Items (owned by several members)
  
 ## Follow-Up Discussion
+
+None.

--- a/wg-releases/meeting-notes/2020-08-26.md
+++ b/wg-releases/meeting-notes/2020-08-26.md
@@ -13,6 +13,7 @@
 
 ## Agenda
 
+None.
 
 ## Backport Requests
 
@@ -27,7 +28,10 @@
     * **Verdict:** Approved for `10-x-y`
 
 ## Action Items
+
+None.
  
 ## Follow-Up Discussion
-* post-summit and OKRs
+
+* Post-summit and OKRs
 * 10.0.0 retro?

--- a/wg-releases/meeting-notes/2020-09-02.md
+++ b/wg-releases/meeting-notes/2020-09-02.md
@@ -1,0 +1,43 @@
+# Releases WG
+
+### Date: 2020-09-02
+
+**Members**
+* @codebytere 
+* @sofianguy 
+* @VerteDinde
+* @deepak1556
+* @jkleinsc 
+* @ckerr 
+* @zcbenz
+* @MarshallOfSound 
+
+**Visitors**
+* @groundwater 
+
+## Agenda
+
+* Post-summit and OKRs
+    * **Main Objective:** Reduce Frustrations of Major App Consumers
+        * **Key Result:** Lower regression count
+            * Regression here is defined in the same way we defined it when triaging the stabilization board
+        * **Key Result:** Reduce time to discovering regressions
+            * Potential questions:
+                * How close, on average, are stable blockers found and fixed to beta.0?
+        * **Key Result:** More comms of upcoming changes
+    * next week: define measure aspect of KRs (add in Miro board)
+* 10.0.0 retro?
+    * Release went smoothly - no comments
+* Review first wave of new 10.x.y stable issues
+
+## Backport Requests
+
+* [Pending votes](https://github.com/electron/electron/pulls?q=is%3Apr+is%3Aopen+label%3A%22backport%2Frequested+%F0%9F%97%B3%22+)
+
+## Action Items
+ 
+None.
+
+## Follow-Up Discussion
+
+None.


### PR DESCRIPTION
Adds notes from yesterday's meeting. Also cleans up some formatting from previous meetings.

cc @electron/wg-releases 