### PR TITLE
docs: tweak text of issue triage playbook responses

### DIFF
--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -1,26 +1,28 @@
 ## If No Repro Included
 
-Thank you for taking the time to report this issue and helping to make Electron better.
+Thanks for reporting this and helping to make Electron better!
 
-Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) to make a stand-alone app that reproduces this issue?
+Would it be possible for you to make a standalone testcase with only the code necessary to reproduce the issue? For example, [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small test cases and makes it easy to publish your test case to a [gist](https://gist.github.com) that Electron maintainers can use.
 
 Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
-I'm adding the `blocked/needs-repro` label for this reason. After you make a test case (a [gist](https://gist.github.com) is preferred since gists can be loaded directly into [Electron Fiddle](https://www.electronjs.org/fiddle) for testing), please link to it in a followup comment.
+I'm adding the `blocked/needs-repro` label for this reason. After you make a test case, please link to it in a followup comment.
 
 Thanks in advance! Your help is appreciated.
 
+
+
 ## If Repro Requires Third-Party Tooling
 
-Thank you for taking the time to report this issue and helping to make Electron better.
+Thanks for reporting this and helping to make Electron better!
 
-Researching issues that depend on third-party code is usually not feasible for the Electron team due to the time that would be required to research reported issues with open-ended dependencies.
+Because of time constraints, triaging code with third-party dependencies is usually not feasible for a small team like Electron's.
 
-Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself without other code?
+Would it be possible for you to make a standalone testcase with only the code necessary to reproduce the issue? For example, [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small test cases and makes it easy to publish your test case to a [gist](https://gist.github.com) that Electron maintainers can use.
 
 Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
-I'm adding the `blocked/needs-repro` label for this reason. After you make a test case (a [gist](https://gist.github.com) is preferred since gists can be loaded directly into [Electron Fiddle](https://www.electronjs.org/fiddle) for testing), please link to it in a followup comment.
+I'm adding the `blocked/needs-repro` label for this reason. After you make a test case, please link to it in a folloup comment.
 
 Thanks in advance! Your help is appreciated.
 

--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -2,11 +2,11 @@
 
 Thank you for taking the time to report this issue and helping to make Electron better.
 
-Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself?
+Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) to make a stand-alone app that reproduces this issue?
 
 Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
-I'm adding the `blocked/needs-repro` label for this reason. After you've responded, please link to the test case and @ me in a followup comment.
+I'm adding the `blocked/needs-repro` label for this reason. After you make a test case (a [gist](https://gist.github.com) is preferred since gists can be loaded directly into [Electron Fiddle](https://www.electronjs.org/fiddle) for testing), please link to it in a followup comment.
 
 Thanks in advance! Your help is appreciated.
 
@@ -14,12 +14,13 @@ Thanks in advance! Your help is appreciated.
 
 Thank you for taking the time to report this issue and helping to make Electron better.
 
-Researching issues that require triaging third-party code is usually not feasable due to the high volume of issues that are reported to Electron.
-Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself without third-party code?
+Researching issues that depend on third-party code is usually not feasible for the Electron team due to the time that would be required to research reported issues with open-ended dependencies.
+
+Would it be possible for you to fork [electron-quick-start](https://github.com/electron/electron-quick-start) for a small app that reproduces the issue by itself without other code?
 
 Stand-alone test cases make fixing issues go more smoothly: it ensure everyone's looking at the same issue, it removes all unnecessary variables from the equation, and it can also provide the basis for automated regression tests.
 
-I'm adding the `blocked/needs-repro` label for this reason. After you've responded, please link to the test case and @ me in a followup comment.
+I'm adding the `blocked/needs-repro` label for this reason. After you make a test case (a [gist](https://gist.github.com) is preferred since gists can be loaded directly into [Electron Fiddle](https://www.electronjs.org/fiddle) for testing), please link to it in a followup comment.
 
 Thanks in advance! Your help is appreciated.
 

--- a/playbooks/responses/end-of-life.md
+++ b/playbooks/responses/end-of-life.md
@@ -1,7 +1,7 @@
 Thank you for reaching out!
 
-The version of Electron reported in this issue has reached end-of-life and is no longer supported, so this issue will be closed.
+The version of Electron reported in this issue has reached end-of-life and is [no longer supported](https://www.electronjs.org/docs/tutorial/support#supported-versions), so this issue will be closed.
 
-If you're still experiencing this issue on a supported version of Electron and would like this issue to remain open, please file a new issue with that version of Electron.
+If you're still experiencing this issue on a [supported version](https://www.electronjs.org/releases/stable) of Electron, please file a new issue for that version of Electron.
 
 Thanks in advance! Your help is appreciated.

--- a/playbooks/responses/end-of-life.md
+++ b/playbooks/responses/end-of-life.md
@@ -1,9 +1,7 @@
-Thank you for taking the time to report this issue and helping to make Electron better.
+Thank you for reaching out!
 
-This issue has been marked for closing because this series of Electron has reached end-of-life and is no longer supported.
+The version of Electron reported in this issue has reached end-of-life and is no longer supported, so this issue will be closed.
 
-If you're still experiencing this issue in the latest version of Electron and would like this issue to remain open, please add a comment specifying the version you're testing with and any other information that a maintainer needs to know to reproduce the issue.
-
-I'm setting the `blocked/need-info` label for the above reasons.
+If you're still experiencing this issue on a supported version of Electron and would like this issue to remain open, please file a new issue with that version of Electron.
 
 Thanks in advance! Your help is appreciated.

--- a/playbooks/responses/needs-template.md
+++ b/playbooks/responses/needs-template.md
@@ -1,5 +1,5 @@
 Thanks for reaching out!
 
-We require the template to be filled out on all new issues and pull requests. We do this so that we can be certain we have all the information we need to address your submission efficiently. This allows the maintainers to spend more time fixing bugs, implementing enhancements, and reviewing and merging pull requests.
+Please fill out the template when filing new issues and pull requests. This is necessary so that we can be certain we have all the information we need to address your submission efficiently and correctly.
 
 Thanks for understanding and meeting us half way :grinning:

--- a/playbooks/responses/needs-template.md
+++ b/playbooks/responses/needs-template.md
@@ -1,5 +1,5 @@
 Thanks for reaching out!
 
-Please fill out the template when filing new issues and pull requests. This is necessary so that we can be certain we have all the information we need to address your submission efficiently and correctly.
+Please provide the information that was requested by the [issue template](https://github.com/electron/electron/tree/master/.github/ISSUE_TEMPLATE) that was presented when you first filled out this issue. This is necessary because it's difficult to triage issues efficiently and correctly without enough information.
 
 Thanks for understanding and meeting us half way :grinning:

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -1,5 +1,7 @@
 ---
-action: close
+action:
+ - add 'discussion' label
+ - close issue
 ---
 
 Thanks for reaching out!

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -1,1 +1,3 @@
-GitHub issues are for feature requests and bug reports, questions about using Electron or code assistance requests should be directed to the [community](https://github.com/electron/electron#community).
+The Electron team uses its issues for tracking feature requests and bug reports.
+
+Please visit https://github.com/electron/electron#community for a list of resources that are better oriented for questions and help. Thank you!

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -6,9 +6,6 @@ action:
 
 Thanks for reaching out!
 
-https://github.com/electron/electron/issues is used for tracking feature requests
-and bug reports, so you will probably find better luck with this question at one
-of the links at https://github.com/electron/electron#community -- in particular,
-be sure to give https://discord.com/invite/electron a try.
+The issues tracker is used for feature requests and bug reports, so you will probably have better luck with this question at one of the links at [the project's Community page](https://github.com/electron/electron#community) -- in particular, be sure to give [the Electron Discord server](https://discord.com/invite/electron) a try.
 
-Good luck! I hope this helps!
+I hope this helps!

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -1,3 +1,12 @@
-The Electron team uses its issues for tracking feature requests and bug reports.
+---
+action: close
+---
 
-Please visit https://github.com/electron/electron#community for a list of resources that are better oriented for questions and help. Thank you!
+Thanks for reaching out!
+
+https://github.com/electron/electron/issues is used for tracking feature requests
+and bug reports, so you will probably find better luck with this question at one
+of the links at https://github.com/electron/electron#community -- in particular,
+be sure to give https://discord.com/invite/electron a try.
+
+Good luck! I hope this helps!

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -6,6 +6,6 @@ action:
 
 Thanks for reaching out!
 
-The issues tracker is used for feature requests and bug reports, so you will probably have better luck with this question at one of the links at [the project's Community page](https://github.com/electron/electron#community) -- in particular, be sure to give [the Electron Discord server](https://discord.com/invite/electron) a try.
+The issues tracker is used for feature requests and bug reports, so you will probably have better luck with this question at one of the links at [the project's Community page](https://www.electronjs.org/community) -- in particular, be sure to give [the Electron Discord server](https://discord.com/invite/electron) a try.
 
 I hope this helps!


### PR DESCRIPTION
I'm on triage duty this week and some of these responses seemed like they needed a refresh -- e.g. improving phrasing, removing commasplices, or pointing users in the right direction. The only unifying theme across the changes is that they were needed by some of the issues that I triaged :smile_cat: and PRing them separately seemed like overkill.

CC @electron/wg-releases 