### PR TITLE
chore: update Outreach WG OKRs for 2020

### DIFF
--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -17,12 +17,12 @@ Grows the Electron community
 ## Current Objective and Key Results
 **Objective:**
 
-Electron is easy for new people to approach and make meaningful contributions.
+Electron has a healthy community that supports app developers and the larger dev community.
 
-**Key Results:**
-* Reduce time needed to set up developer environment
-* Increase breadth of contributors across organizations
-* Increase the number of regular contributors (rolling 90-day active)
+**Initiatives:**
+* Electron Discord with 500 users and a documented moderation system
+* Post 1 technical blog post every other month (from maintainers or guest authors)
+* Amplify the work of the other working groups and get community feedback
 
 ## Membership Requirements
 


### PR DESCRIPTION
Back in August, we had a meeting to update our OKRs since we didn't finalize them during the Electron Maintainer Summit. We generated an Objective and a few Initiatives, but never updated our working group's public README.

Here we go, 2 months later!

Miro board, for reference: https://miro.com/app/board/o9J_knuYqMI=/

To review: we also had "Measures" written down on the board. Do we want these to be on the README as well? cc @groundwater @molant 

As a note, we also had an action item to write a blog post about the output from the Summit, but I think that ship has sailed at this point. Maybe next time?