### PR TITLE
chore: Join admin, leave outreach & ecosystem

### DIFF
--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -19,9 +19,8 @@ It is important that other working groups have autonomy and agency to fulfill th
 | Avatar | Name | Role | Time Zone |
 | -------------------------------------------|----------------------|----------------------------| -------- |
 | <img src="https://github.com/groundwater.png" width=100 alt="@groundwater">  | Jacob Groundwater [@groundwater](https://github.com/groundwater) | Member | PT (San Francisco) |
-| <img src="https://github.com/mgc.png" width=100 alt="@mgc">  | Matt Crocker [@mgc](https://github.com/mgc) | **Chair** | PT (San Francisco) |
-| <img src="https://github.com/molant.png" width=100 alt="@molant">  | Antón Molleda [@molant](https://github.com/molant) | Member | PST (Seattle) |
-| <img src="https://github.com/deanihansen.png" width=100 alt="@deanihansen">  | Deani Hansen [@deanihansen](https://github.com/deanihansen) | Member | PST (Vancouver) |
+| <img src="https://github.com/molant.png" width=100 alt="@molant">  | Antón Molleda [@molant](https://github.com/molant) | **Chair** | PST (Seattle) |
+| <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg">  | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | Member | PT (San Francisco) |
 | | Governance Representative | Member | |
 | | Community Representative | Member | |
 

--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -9,7 +9,6 @@ Oversees the projects that make Electron app development easier.
 | <img src="https://github.com/vhashimotoo.png" width=100 alt="@vhashimotoo">  | Vlad Hashimoto [@vhashimotoo](https://github.com/vhashimotoo) | Chair | CET (Germany, Frankfurt am Main) |
 | <img src="https://github.com/ckerr.png" width=100 alt="@ckerr">  | Charles Kerr [@ckerr](https://github.com/ckerr) | Member | CT (New Orleans) |
 | <img src="https://github.com/erickzhao.png" width=100 alt="@erickzhao">  | Erick Zhao [@erickzhao](https://github.com/erickzhao) | Member | PT (Vancouver) |
-| <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg">  | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | Member | PT (San Francisco) |
 | <img src="https://github.com/kilian.png" width=100 alt="@kilian">  | Kilian Valkhof [@kilian](https://github.com/kilian) | Member | CET (Netherlands) |
 | <img src="https://github.com/malept.png" width=100 alt="@malept">  | Mark Lee [@malept](https://github.com/malept) | Member | PT (Seattle) |
 | <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -6,7 +6,6 @@ Grows the Electron community
 | ------ | ---- | ---- | --------- |
 | <img src="https://github.com/erickzhao.png" width=100 alt="@erickzhao">  | Erick Zhao [@erickzhao](https://github.com/erickzhao) | **Chair** | PT (Vancouver) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
-| <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg">  | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | Member | PT (San Francisco) |
 | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
 | <img src="https://github.com/ckerr.png" width=100 alt="@ckerr">  | Charles Kerr [@ckerr](https://github.com/ckerr) | Member | CT (New Orleans) |
 | <img src="https://github.com/cruzerld.png" width=100 alt="@cruzerld">  | David Cruz [@cruzerld](https://github.com/cruzerld) | Member | ET (New York City) |
@@ -28,7 +27,7 @@ Electron is easy for new people to approach and make meaningful contributions.
 
 ### Becoming a member
 
-Anyone interested in supporting the Electron community is invited to consider joining this working group. Possible inductees need to be approved by a 2/3 majority vote of existing working group members. 
+Anyone interested in supporting the Electron community is invited to consider joining this working group. Possible inductees need to be approved by a 2/3 majority vote of existing working group members.
 
 ### Membership requirements
 
@@ -36,7 +35,7 @@ Being an active member of this working group requires that you actively particip
 
  * We expect members to regularly attend working group meetings
  * We expect members to actively devote time or other resources to outreach work on an ongoing basis
- 
+
 Examples for work include writing or improving onboarding documentation, meeting and communicating with companies building apps on top of Electron, organizing conferences or meetups, or answering developer questions on social media. Helping developers building apps with Electron and community members interested in contributing to Electron can take on countless forms.
 
 ## Areas of Responsibility


### PR DESCRIPTION
With my new role at Slack comes a move at Electron, too -- and I'm joining `wg-admin` to take over the baton from Slack's previous members in that working group.

We've always said that members of `wg-admin` shouldn't have a vote in any of the operative working groups, which I believe is the correct principle to follow. The way I see it, I can still work on `fiddle` and contribute to various outreach projects, I'll just need to follow what those two working groups think. With that in mind, I'm not going anywhere - I'm just swapping out my two voting positions for another one.

(Also, we've discussed that @molant is now the chair of `wg-admin`)