### PR TITLE
docs: add @wg-outreach meeting minutes 2020-10-26

### DIFF
--- a/wg-outreach/meeting-notes/2020-10-26.md
+++ b/wg-outreach/meeting-notes/2020-10-26.md
@@ -1,0 +1,30 @@
+# Outreach WG
+
+Date: October 26, 2020
+
+## Attendees
+
+**Members:**
+* @bnb
+* @erickzhao
+* @sofianguy
+
+**Visitors:**
+* @anmol27katyani
+* @vhashimotoo 
+
+## Agenda
+
+- Discord Update
+  - We have a new help bot!
+  - We've reached 500 members, but we still need to reach a minimum activity threshold. Let's keep an eye
+  on our insights until we meet it.
+  - Differentiating us from the Roblox hack?
+  - Loosening up verification gates? ([Context](https://twitter.com/jna_sh/status/1316017725152522242))
+    - A great majority of users are able to find the appropriate Reactji. Let's keep the gate.
+    - @bnb will make CTA better.
+- Hacktoberfest Update
+  - Tweet now (@bnb)
+Twitter rollup at the end of the month
+- Electron at OpenJS World 2021
+  - We're open to having our own track, but not sure how much engagement we'll have from proposals?


### PR DESCRIPTION
Note that @vhashimotoo has decided to withdraw from Electron Governance, but will continue to help with maintaining our Discord server.

Action items:

* @bnb: improve Discord server CTA for verification gate

