### PR TITLE
docs: add i18n playbook

### DIFF
--- a/playbooks/responses/i18n.md
+++ b/playbooks/responses/i18n.md
@@ -1,7 +1,7 @@
 Thank you for reporting this translation error!
 
 Translations of Electron's documentation fed into the [`electron-i18n`](https://github.com/electron/i18n) repository via [CrowdIn](https://crowdin.com/project/electron).
-In order to correct any mistranslated strings, we accept changes to the [<Insert Language> translations on the CrowdIn platform itself](https://crowdin.com/project/electron/ar).
+In order to correct any mistranslated strings, we accept changes to the [<Insert Language> translations on the CrowdIn platform itself](https://crowdin.com/project/electron/<Insert Language Code>).
 For more details on how this data eventually makes its way to our website, check out our [Website Infrastructure](https://github.com/electron/electronjs.org/blob/master/docs/infrastructure.md#electron-i18n)
 doc.
 

--- a/playbooks/responses/i18n.md
+++ b/playbooks/responses/i18n.md
@@ -4,3 +4,6 @@ Translations of Electron's documentation fed into the [`electron-i18n`](https://
 In order to correct any mistranslated strings, we accept changes to the [<Insert Language> translations on the CrowdIn platform itself](https://crowdin.com/project/electron/ar).
 For more details on how this data eventually makes its way to our website, check out our [Website Infrastructure](https://github.com/electron/electronjs.org/blob/master/docs/infrastructure.md#electron-i18n)
 doc.
+
+If you're interested in participating in discussion regarding the translation of Electron docs, we have an internationalization channel
+available on our [community Discord server](https://discord.gg/electron)!

--- a/playbooks/responses/i18n.md
+++ b/playbooks/responses/i18n.md
@@ -1,0 +1,6 @@
+Thank you for reporting this translation error!
+
+Translations of Electron's documentation fed into the [`electron-i18n`](https://github.com/electron/i18n) repository via [CrowdIn](https://crowdin.com/project/electron).
+In order to correct any mistranslated strings, we accept changes to the [<Insert Language> translations on the CrowdIn platform itself](https://crowdin.com/project/electron/ar).
+For more details on how this data eventually makes its way to our website, check out our [Website Infrastructure](https://github.com/electron/electronjs.org/blob/master/docs/infrastructure.md#electron-i18n)
+doc.


### PR DESCRIPTION
Adds a reusable response for translation errors on `electronjs.org`. These usually pop up either in `electron/electron`, `electron/electronjs.org`, and `electron/i18n`.

cc @molant 