### PR TITLE
docs: update meeting times for DST

### DIFF
--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -120,7 +120,7 @@ These repos are sorted alphabetically, their order does not reflect that any of 
 
 ## Meeting Schedule
 
-**Sync Meeting** 30min every other Thursday @ [17:00 UTC](https://duckduckgo.com/?q=17%3A00+UTC&ia=answer)
+**Sync Meeting** 30min every other Thursday @ [18:00 UTC](https://duckduckgo.com/?q=18%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).
 

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -47,6 +47,6 @@ Examples for work include writing or improving onboarding documentation, meeting
 - Electron meetup events
 
 ## Meeting Schedule
-- **Sync Meeting** 60 min meeting every other Monday @ [17:00 UTC](https://duckduckgo.com/?q=17%3A00+UTC&ia=answer)
+- **Sync Meeting** 60 min meeting every other Monday @ [18:00 UTC](https://duckduckgo.com/?q=18%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).


### PR DESCRIPTION
For @electron/wg-outreach and @electron/wg-ecosystem, updated README times to reflect the DST change.