### PR TITLE
docs: add November 18, 2020 Release WG notes

### DIFF
--- a/wg-releases/meeting-notes/2020-11-18.md
+++ b/wg-releases/meeting-notes/2020-11-18.md
@@ -1,0 +1,37 @@
+# Releases WG
+
+### Date: November 18, 2020
+
+**Members**
+* @mlaurencin 
+* @VerteDinde
+* @codebytere
+* @jkleinsc
+* @zcbenz
+* @deepak1556
+* @sofianguy
+* @ckerr
+* @MarshallOfSound
+
+## Agenda
+
+1. Auditing outstanding PRs before every release kick
+  * [#26528](https://github.com/electron/electron/pull/26528) was missed very close to `11.0.1` release 
+  * Conclusion: group to announce a release is going at X time in #wg-releases, but group understanding that sometimes this announcement won’t have long heads up beforehand.
+2. Check in about `11.0.0` and `12.0.0-beta.1`
+3. Chair rotation
+  * @VerteDinde selected as next chair! 
+
+## Backport Requests
+
+1. [#26549](https://github.com/electron/electron/issues/26549) 
+* Defer to API working group because [#26134](https://github.com/electron/electron/pull/26134) and [#26135](https://github.com/electron/electron/pull/26135) are arguably breaking changes. If API WG determines these to be breaking changes we can’t backport and would need to be marked as breaking changes for `v12`.
+* Set: 
+  * [#25284](https://github.com/electron/electron/pull/25284)
+  * [#24937](https://github.com/electron/electron/pull/24937)
+  * [#26135](https://github.com/electron/electron/pull/26135)
+  * [#26134](https://github.com/electron/electron/pull/26134)
+
+## Action Items
+
+None.


### PR DESCRIPTION
Adds notes from today's meeting.