### PR TITLE
chore: update Releases WG chair, add 04-14-2021 releases notes

### DIFF
--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -6,10 +6,10 @@ Oversees all release branches, and tooling to support releases.
 
 | Avatar | Name | Role | Time Zone |
 | -------------------------------------------|----------------------|----------------------------| -------- |
-| <img src="https://github.com/vertedinde.png" width=100 alt="@vertedinde">  | Keeley Hammond [@VerteDinde](https://github.com/vertedinde) | **Chair** | PT (Portland) |
+| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | **Chair** | PT (Vancouver) |
 | <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | ET (Harrisburg) |
 | <img src="https://github.com/ckerr.png" width=100 alt="@ckerr">  | Charles Kerr [@ckerr](https://github.com/ckerr) | Member | CT (New Orleans) |
-| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |
+| <img src="https://github.com/vertedinde.png" width=100 alt="@vertedinde">  | Keeley Hammond [@VerteDinde](https://github.com/vertedinde) | Member | PT (Portland) |
 | <img src="https://github.com/deepak1556.png" width=100 alt="@deepak1556">  | Deepak Mohan [@deepak1556](https://github.com/deepak1556) | Member | PT (Vancouver) |
 | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy">  | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
 | <img src="https://github.com/zcbenz.png" width=100 alt="@zcbenz">  | Cheng Zhao [@zcbenz](https://github.com/zcbenz) | Member | JST (Nagoya) |

--- a/wg-releases/meeting-notes/2021-04-14.md
+++ b/wg-releases/meeting-notes/2021-04-14.md
@@ -1,0 +1,32 @@
+# Releases WG
+
+### Date: April 14, 2021
+
+## Members
+- Cheng Zhao
+- Calvin Watford
+- Michaela Laurencin
+- Sofia Nguy
+- Keeley Hammond
+- John Kleinschmidt
+- Charles Kerr
+- Samuel Attard
+- Shelley Vohr
+
+## Visitors
+- None
+
+
+## Agenda
+- Review Anton Molleda’s backport PR: https://github.com/electron/trop/pull/190
+- Next Releases WG Chair
+  - Samuel Attard is the next Releases WG chair!
+
+
+## Backport Requests
+None
+
+
+## Action Items from past meetings
+For April: Ask other apps about new Chromium schedule
+For April/May:Begin work on this issue early https://github.com/electron/electron/issues/28414 


### PR DESCRIPTION
This PR updates the Releases WG README to show that @MarshallOfSound is now the Releases Chair (🎉) and adds meeting notes for the April 14 Releases meeting.