### PR TITLE
docs: add retro for 15.0.0-alpha1

### DIFF
--- a/wg-releases/retros/15.0.0-alpha1.md
+++ b/wg-releases/retros/15.0.0-alpha1.md
@@ -11,7 +11,7 @@ At 3:04 PM PST we queued another release attempt which successfully bumped the v
 
 ### Incident Causes
 
-The first and primary issue was that we failed to initiate a release on July 20th, the first release of a given branch is always a manual process and in this case there was no clear owner of the [cut release branch](https://github.com/electron/electron/projects/31#card-65436776) task.  This was also partially due to not having a clear go/no-go metric for whether all the other dependent tasks were complete, this hesitation lead to a delay.
+The first and primary issue was that we failed to initiate a release on July 20th, the first release of a given branch is always a manual process and in this case there was no clear owner of the [cut release branch](https://github.com/electron/electron/projects/31#card-65436776) task.  This was also partially due to not having a clear go/no-go metric for whether all the other dependent tasks were complete, this hesitation led to a delay.
 
 The secondary issues were:
 

--- a/wg-releases/retros/15.0.0-alpha1.md
+++ b/wg-releases/retros/15.0.0-alpha1.md
@@ -1,0 +1,29 @@
+# Delayed Ship Date Retro - Electron `v15.0.0-alpha.1`
+## July 21st, 2021
+
+### What Happened
+
+Per our pre-published [release schedule](https://www.electronjs.org/blog/8-week-cadence), the Electron team planned to release the first alpha version of Electron 15.0.0 on July 20th, 2021.  We triggered the first release attempt at 1:45 PM PST on July 21st.  This release hung and failed to proceed with no alerting at 1:46 PM PST.  This release attempt was manually aborted at 2:43 PM PST.
+
+A huddle was initiated at 2:36 PM PST to attempt to identify the issue with the first release attempt as there was no obvious error.  After noticing some patterns in the Sudowoodo logs we identified a potential infinite loop in Electron's release notes generator and [queued up a fix](https://github.com/electron/electron/commit/82b5fbc396e183f668497237829f5562bb7e05c0).
+
+At 3:04 PM PST we queued another release attempt which successfully bumped the version and started release builds, at 4:55 PM PST the release builds completed and Sudowoodo prompted for a 2FA token.  At this point Sudowoodo failed to complete the "npm publish" phase of the release process though as far as we could tell the package had been published and the GitHub release was public.  At 4:59 PM PST we identified a bug in the final line of the [`publish-to-npm.js`](https://github.com/electron/electron/blob/main/script/release/publish-to-npm.js#L182-L185) script where it would fail to create the `alpha` npm dist-tag if no previous alpha tag existed.  We concluded that we could manually tag this release and then in the future the existing code would work as expected, at 5:02 PM PST the npm package was manually tagged and the release was declared complete.
+
+### Incident Causes
+
+The first and primary issue was that we failed to initiate a release on July 20th, the first release of a given branch is always a manual process and in this case there was no clear owner of the [cut release branch](https://github.com/electron/electron/projects/31#card-65436776) task.  This was also partially due to not having a clear go/no-go metric for whether all the other dependent tasks were complete, this hesitation lead to a delay.
+
+The secondary issues were:
+
+1. Our release notes generator had a hard to identify infinite loop condition when our prior assumptions around "a prerelease branch is always preceeded by a stable branch" failed to hold true.
+2. Our npm publish script had a flaw for the first release of a new tag
+
+Troubleshooting and fixing both of these issues was quite quick and they would not have independently caused the release delay.
+
+### How This Could Have Been Prevented
+
+In order to prevent this from happening we could have clearly assigned owners for _everything_ on the E15 cadence project board, missing an owner on such a key item was the root cause of this delay.
+
+### Future Actions
+
+In the future, we will assign owners for all release tasks the week before the release is expected to be cut.


### PR DESCRIPTION
Timeline written up and conclusions conveyed from the retro last wednesday

cc @electron/wg-releases 