### PR TITLE
fix: phrasing for attending consecutive meetings.

### DIFF
--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -66,7 +66,7 @@ This is done primarily to ensure that there are no open avenues of compromise fo
 
 ## Meeting Schedule
 
-* **Sync Meeting** 1 hour every Wednesday at [23:00 UTC](https://duckduckgo.com/?q=23%3A00+UTC&ia=answer)
+* **Sync Meeting** 1 hour each Wednesday, alternating between two times: [16:30 UTC](https://duckduckgo.com/?q=16%3A30+UTC&ia=answer) and [23:00 UTC](https://duckduckgo.com/?q=23%3A00+UTC&ia=answer).
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).
 


### PR DESCRIPTION
Now that @electron/wg-releases  has meetings in alternating timezones, the original phrasing "three consecutive meetings" has an unintended requirement of attending meetings in the middle of the night. This PR fixes that by saying regular attendance, which seems clearer / less clunky than spelling out "attendance in your own timezone and optionally in the other timezone meetings"

Discussed in the 2021-10-13 meeting