### PR TITLE
chore(playbooks): update Electron Discord invite links

### DIFF
--- a/playbooks/responses/i18n.md
+++ b/playbooks/responses/i18n.md
@@ -6,4 +6,4 @@ For more details on how this data eventually makes its way to our website, check
 doc.
 
 If you're interested in participating in discussion regarding the translation of Electron docs, we have an internationalization channel
-available on our [community Discord server](https://discord.gg/electron)!
+available on our [community Discord server](https://discord.gg/electronjs)!

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -6,6 +6,6 @@ action:
 
 Thanks for reaching out!
 
-The issues tracker is used for feature requests and bug reports, so you will probably have better luck with this question at one of the links at [the project's Community page](https://www.electronjs.org/community) -- in particular, be sure to give [the Electron Discord server](https://discord.com/invite/electron) a try.
+The issues tracker is used for feature requests and bug reports, so you will probably have better luck with this question at one of the links at [the project's Community page](https://www.electronjs.org/community) -- in particular, be sure to give [the Electron Discord server](https://discord.com/invite/electronjs) a try.
 
 I hope this helps!


### PR DESCRIPTION
They got updated at the beginning of the year but the playbooks didn't.