### PR TITLE
docs: revise the blocked-needs-repo playlist entry

### DIFF
--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -2,24 +2,14 @@
 
 Thanks for reporting this and helping to make Electron better!
 
-Would it be possible for you to make a standalone testcase with only the code necessary to reproduce the issue? [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small testcases and publishing them as [gists](https://gist.github.com) that Electron maintainers can use.
+Please use [Electron Fiddle](https://github.com/electron/fiddle) to create a standalone (no external dependencies) testcase and publish it as a [gist](https://gist.github.com), then link to it here.
 
-If the bug you've found can be tested with a pass / fail test, please make the testcase [exit 0 on success or nonzero on failure](https://github.com/electron/bugbot#by-bug-reporters). The lets [Electron's issue bot](https://github.com/electron/bugbot#readme) see what releases are affected by the bug by checking your test against different OSes and Electron versions.
+- Even if you have a code snippet or a git repository that show the testcase, please put it in a gist. This lets maintainers triage issues more effectively. It also ensures that we're testing the exact same issue that you're seeing!
 
-I'm adding the `blocked/need-repro` label for this reason. After you make a test case, please link to it in a followup comment.
+- Please avoid external dependencies in the test. The Electron team is small and generally doesn't have enough bandwidth to triage third-party code. Also, standalone tests are easier to adapt into regression tests.
 
-Thanks in advance! Your help is appreciated.
+- If the bug you've found can be tested with a pass / fail test, please make the testcase [exit 0 on success or nonzero on failure](https://github.com/electron/bugbot#by-bug-reporters). The lets [Electron's issue bot](https://github.com/electron/bugbot#readme) see what releases are affected by the bug.
 
-
-
-## If Repro Requires Third-Party Tooling
-
-Thanks for reporting this and helping to make Electron better!
-
-Because of time constraints, triaging code with third-party dependencies is usually not feasible for a small team like Electron's. Would it be possible for you to make a standalone testcase with only the code necessary to reproduce the issue? [Electron Fiddle](https://www.electronjs.org/fiddle) is a great tool for making small testcases and publishing them as [gists](https://gist.github.com) that Electron maintainers can use.
-
-If the bug you've found can be tested with a pass/fail test, please make the testcase [exit 0 on success or nonzero on failure](https://github.com/electron/bugbot#by-bug-reporters). The lets [Electron's issue bot](https://github.com/electron/bugbot#readme) see what releases are affected by the bug by checking your test against different OSes and Electron versions.
-
-I'm adding the `blocked/need-repro` label for this reason. After you make a test case, please link to it in a followup comment.
+I'm adding the `blocked/need-repro` label for this reason. After you make a test case, please link to the gist in a followup comment.
 
 Thanks in advance! Your help is appreciated.

--- a/playbooks/responses/blocked-needs-repro.md
+++ b/playbooks/responses/blocked-needs-repro.md
@@ -8,7 +8,7 @@ Please use [Electron Fiddle](https://github.com/electron/fiddle) to create a sta
 
 - Please avoid external dependencies in the test. The Electron team is small and generally doesn't have enough bandwidth to triage third-party code. Also, standalone tests are easier to adapt into regression tests.
 
-- If the bug you've found can be tested with a pass / fail test, please make the testcase [exit 0 on success or nonzero on failure](https://github.com/electron/bugbot#by-bug-reporters). The lets [Electron's issue bot](https://github.com/electron/bugbot#readme) see what releases are affected by the bug.
+- If the bug you've found can be tested with a pass / fail test, please make the testcase [exit 0 on success or nonzero on failure](https://github.com/electron/bugbot#by-bug-reporters). This lets [Electron's issue bot](https://github.com/electron/bugbot#readme) see what releases are affected by the bug.
 
 I'm adding the `blocked/need-repro` label for this reason. After you make a test case, please link to the gist in a followup comment.
 


### PR DESCRIPTION
Revised based on some of the things that we've discussed this week at the SF hackweek.

CC @electron/wg-releases 