### PR TITLE
chore: master -> main in docs

### DIFF
--- a/policy/permissions.md
+++ b/policy/permissions.md
@@ -43,7 +43,7 @@ All [maintainers](../charter/README.md#definitions) are granted "Write" permissi
 
 All Working Group Members are granted "Write" permissions to the **private** repositories that their group is responsible for, and the working group can decide on access to nonmembers. This is documented in the `repos.md` file in each `wg-*` directory in this Governance repository.
 
-Although "Write" access may be granted to the repository this does **not** implicitly grant `master` / Protected Branch rights. They shall be determined by the Working Group that owns each repository but as a general policy, all repositories should have their `master` branch set as a Protected Branch.
+Although "Write" access may be granted to the repository this does **not** implicitly grant `main` / Protected Branch rights. They shall be determined by the Working Group that owns each repository but as a general policy, all repositories should have their `main` branch set as a Protected Branch.
 
 If a repository has multiple Working Group stakeholders, access will be determined by a vote from the chairs of _all_ working groups. Any chair may abstain.  The vote must be at least 2/3 of participating chairs.
 

--- a/wg-releases/feature-backport-requests.md
+++ b/wg-releases/feature-backport-requests.md
@@ -1,6 +1,6 @@
 ## Feature Backport Requests
 
-Backporting non-breaking features to supported versions requires the approval of the Releases Working Group. Any feature PR that is targeting branch(es) other than master should be labeled with a `backport/requested 🗳` label.
+Backporting non-breaking features to supported versions requires the approval of the Releases Working Group. Any feature PR that is targeting branch(es) other than `main` should be labeled with a `backport/requested 🗳` label.
 
 The approval process works as follows:
 1. By requesting backport of a feature, the submitter of the PR is assuming responsibility for this feature on the requested branches.

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -9,7 +9,7 @@ One week before stable promotion for a given release line, we should release a f
 Before releasing the final beta, we need to ensure we have fixed all stable blocker items. Afterwards, we need to ensure that there remain no unmerged pull requests targeting that branch. This entails two tasks:
 
 1) Run `/check-unmerged <branch-name>` in Slack and see if any PRs are returned
-2) Check open PRs to `master` on `electron/electron` and ensure that none of them carry the label `target/<branch-name>`
+2) Check open PRs to `main` on `electron/electron` and ensure that none of them carry the label `target/<branch-name>`
 
 If both tasks are complete, proceed with the final beta release.
 
@@ -63,7 +63,7 @@ After a new major line has been officially stabilized, we should begin to prepar
 
 For this, we need to ensure the following:
 
-* We have a new Node Module Version (NMV) for the line that follows what is about to become the new `master` major
+* We have a new Node Module Version (NMV) for the line that follows what is about to become the new `main` major
 * Sudowoodo is capable of handling betas for the new major line in its [release options](https://github.com/electron/sudowoodo/blob/master/src/slack-manager.ts#L240-L265)
 * [`node-abi`](https://github.com/lgeiger/node-abi) beta update
   * We should ensure that ABI version information is added for the first beta in the new major stabilization line

--- a/wg-releases/sudowoodo.md
+++ b/wg-releases/sudowoodo.md
@@ -9,7 +9,7 @@ Only authorized releasers have the ability to trigger Sudowoodo, and they can be
 In order to trigger a new release:
 
 1. Invoke `/sudowoodo` as a backslack command in the `#bot-releases` Slack channel.
-2. Choose the correct release branch (`master`, `5-0-x`, etc.) and release type (`stable`, `beta`, `nightly`) from the dropdown in the resulting dialog.
+2. Choose the correct release branch (`main`, `5-0-x`, etc.) and release type (`stable`, `beta`, `nightly`) from the dropdown in the resulting dialog.
 3. Monitor the resulting release until builds are finished and Sudowoodo is preparing to publish the new release to npm
 4. Enter the OTP needed to publish the builds to npm (similarly gated to `sudowoodo-trainers`)
 5. Celebrate 🎉


### PR DESCRIPTION
Changes lingering references from `master` to `main`.