### PR TITLE
chore: update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ The Electron organization and all repos therein adhere to the following [Code of
 
 ## License
 
-Electron is licensed with an [MIT License](https://github.com/electron/electron/blob/master/LICENSE).
+Electron is licensed with an [MIT License](https://github.com/electron/electron/blob/main/LICENSE).

--- a/charter/README.md
+++ b/charter/README.md
@@ -42,8 +42,8 @@ These are our core values, as voted by the maintainers, in order of importance. 
 ## Participation
 
  * [Code of Conduct](../CODE_OF_CONDUCT.md)
- * [Using Slack](https://github.com/electron/governance/blob/master/policy/slack.md)
- * [Triaging Issues](https://github.com/electron/governance/blob/master/playbooks/README.md)
+ * [Using Slack](../policy/slack.md)
+ * [Triaging Issues](../playbooks/README.md)
 <!-- * [Using Pull Requests](FIXME: link to PR etiquette doc) -->
 
 ## Working Groups

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -11,6 +11,5 @@ Playbooks for Electron issue triage, moderation, security incidents, etc
 
 ## See Also
 
-* [electron/electron Issue Template](https://github.com/electron/electron/blob/master/.github/ISSUE_TEMPLATE.md)
-* [electron/electron Welcome Probot Config](https://github.com/electron/electron/blob/master/.github/config.yml)
-* [electron/electron Stale Probot Config](https://github.com/electron/electron/blob/master/.github/stale.yml)
+* [electron/electron Bug Issue Template](https://github.com/electron/electron/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml)
+* [electron/electron Welcome Probot Config](https://github.com/electron/electron/blob/main/.github/config.yml)

--- a/playbooks/responses/duplicate-notification.md
+++ b/playbooks/responses/duplicate-notification.md
@@ -4,4 +4,4 @@ We noticed that this is a duplicate of [Issue URL]. You may want to subscribe th
 
 Because we treat our issues list as [the project team's backlog](https://en.wikipedia.org/wiki/Scrum_(software_development)#Product_backlog), we close duplicates to focus our work and not have to touch the same chunk of code for the same reason multiple times. This is also why we may mark something as duplicate that isn't an exact duplicate but is closely related.
 
-For information on how to use GitHub's search feature to find out if something is a duplicate before filing, see [the CONTRIBUTING guide](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
+For information on how to use GitHub's search feature to find out if something is a duplicate before filing, see [the CONTRIBUTING guide](https://github.com/electron/electron/blob/main/CONTRIBUTING.md).

--- a/playbooks/responses/first-warning.md
+++ b/playbooks/responses/first-warning.md
@@ -1,3 +1,3 @@
-[[at-mention]] your comment was [[minimized|deleted]] as a violation of [the Electron Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md). You may consider this an official warning.
+[[at-mention]] your comment was [[minimized|deleted]] as a violation of [the Electron Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md). You may consider this an official warning.
 
 **Please do not interact with the project for 24 hours.** After that, please look through your open issues and edit them to ensure they're entirely on-topic, and we can continue the discussion here about the best way to go forward.

--- a/playbooks/responses/how-it-works.md
+++ b/playbooks/responses/how-it-works.md
@@ -3,4 +3,4 @@ Open source is largely volunteer-driven and collaborative. Because of this, time
 * We might not have an ETA for when an issue will get investigated or fixed.
 * Something you want implemented might not get implemented.
 * A change you want merged might not get merged.
-* Insisting on or making demands for any of the above is considered against [the Electron Code of Conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md)
+* Insisting on or making demands for any of the above is considered against [the Electron Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md)

--- a/playbooks/responses/needs-template.md
+++ b/playbooks/responses/needs-template.md
@@ -1,5 +1,5 @@
 Thanks for reaching out!
 
-Please provide the information that was requested by the [issue template](https://github.com/electron/electron/tree/master/.github/ISSUE_TEMPLATE) that was presented when you first filled out this issue. This is necessary because it's difficult to triage issues efficiently and correctly without enough information.
+Please provide the information that was requested by the [issue template](https://github.com/electron/electron/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml) that was presented when you first filled out this issue. This is necessary because it's difficult to triage issues efficiently and correctly without enough information.
 
 Thanks for understanding and meeting us half way :grinning:

--- a/policy/joining-governance.md
+++ b/policy/joining-governance.md
@@ -25,7 +25,7 @@ After all the requirements above are completed, follow these steps below to add 
 
 6. Submit a pull request to add the new member's GitHub handle under the approved Working Group in the `config.yaml` file in [.permissions repo](https://github.com/electron/.permissions/). Typically the current WG chair will submit this.
 
-7. A member of [Community & Safety WG](https://github.com/electron/governance/tree/master/wg-community-safety#membership) adds an approval review the PR in .permissions repo.
+7. A member of [Community & Safety WG](../wg-community-safety/README.md#membership) adds an approval review the PR in .permissions repo.
 
 8. Merge .permissions PR. This final step will automatically add the new member to:
     * The WG's team on GitHub

--- a/policy/pull-requests.md
+++ b/policy/pull-requests.md
@@ -4,7 +4,7 @@ Be polite and assume the other parties are acting in good faith.
 
 ## Making Pull Requests
 
-The PR shall follow all the guidelines set forth in the repos' PR templates. For the example of `electron/electron`, [this template](https://github.com/electron/electron/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
+The PR shall follow all the guidelines set forth in the repos' PR templates. For the example of `electron/electron`, [this template](https://github.com/electron/electron/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
 
 If the PR fixes an issue, the PR must mention that issue in the PR body, e.g. [Fixes #123](https://help.github.com/en/articles/closing-issues-using-keywords).
 

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -1,6 +1,6 @@
 # Electron API Design Guidelines
 
-The following are a set of guidelines for building Electron APIs. This document is maintained by the [API Working Group](https://github.com/electron/governance/tree/master/wg-api).
+The following are a set of guidelines for building Electron APIs. This document is maintained by the [API Working Group](./README.md).
 
 ## Questions to ask for every API change
 These questions are intended to prompt reflection and bring up things that the API author may not have considered when designing the API.

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -1,6 +1,6 @@
 # Electron API Design Guidelines
 
-The following are a set of guidelines for building Electron APIs. This document is maintained by the [API Working Group](./README.md).
+The following are a set of guidelines for building Electron APIs. This document is maintained by the [API Working Group](./).
 
 ## Questions to ask for every API change
 These questions are intended to prompt reflection and bring up things that the API author may not have considered when designing the API.

--- a/wg-releases/feature-backport-requests.md
+++ b/wg-releases/feature-backport-requests.md
@@ -14,4 +14,4 @@ The approval process works as follows:
   * Due to the distributed nature of the Releases WG, a backport request that doesn't have consensus may take longer to be approved or rejected until all available members can weigh in.
 4. Once a backport request has been decided upon the PR will be labeled appropriately with either a `backport/approved ✅` or `backport/declined ❌` label.
 
-Please note that during our quiet period during our [Final Beta Release](https://github.com/electron/governance/blob/master/wg-releases/major-release-process.md#final-beta-release), we will not accept feature backports to the major release line in beta.
+Please note that during our quiet period during our [Final Beta Release](./major-release-process.md#final-beta-release), we will not accept feature backports to the major release line in beta.

--- a/wg-releases/issue-playbook/duplicate.md
+++ b/wg-releases/issue-playbook/duplicate.md
@@ -2,4 +2,4 @@ This is a duplicate of [Issue URL]. You may want to subscribe there for updates.
 
 We close duplicates to focus our work and not have to touch the same chunk of code for the same reason multiple times. This is also why we may mark something as duplicate that isn't an exact duplicate but is closely related.
 
-For information on how to use GitHub's search feature to find out if something is a duplicate before filing, see [the CONTRIBUTING guide](https://github.com/electron/electron/blob/master/CONTRIBUTING.md).
+For information on how to use GitHub's search feature to find out if something is a duplicate before filing, see [the CONTRIBUTING guide](https://github.com/electron/electron/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
- Changed links to `electron/electron` to use `main`
- Switched to relative links for within this repo
- Changed links to `electron/electron/blob/master/.github/ISSUE_TEMPLATE` to `electron/electron/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml` since the former no longer exists