### PR TITLE
chore: remove old OKRs from WGs

### DIFF
--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -20,21 +20,6 @@ Oversees the projects that make Electron app development easier.
 | <img src="https://github.com/georgexu99.png" width=100 alt="@blackhole1">  | George Xu [@georgexu99](https://github.com/georgexu99) | Member | PT (San Francisco) |
 
 
-## Current Objective and Key Results
-**Objective:**
-
-As a newcomer or experienced app developer, you can use Electron’s tooling and documentation to build your app well.
-
-**Key Results:**
-
-* [Spectron](https://github.com/electron-userland/spectron) and [Devtron](https://github.com/electron-userland/devtron) are no longer in limbo
-* [Electron Forge](https://github.com/electron-userland/electron-forge) v6 to the finish line
-* Website has a better information architecture
-
-Initiatives:
-* Allow access multiple versions of the docs on the website
-* Identify pain points in user documentation
-
 ## Areas of Responsibility
 
 These projects are sorted alphabetically, their order does not reflect that any of them are "better" or "more important" than others.

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -14,16 +14,6 @@ Grows the Electron community
 | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
 
-## Current Objective and Key Results
-**Objective:**
-
-Electron has a healthy community that supports app developers and the larger dev community.
-
-**Initiatives:**
-* Electron Discord with 500 users and a documented moderation system
-* Post 1 technical blog post every other month (from maintainers or guest authors)
-* Amplify the work of the other working groups and get community feedback
-
 ## Membership Requirements
 
 ### Becoming a member

--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -19,15 +19,6 @@ Oversees all release branches, and tooling to support releases.
 | <img src="https://github.com/deermichel.png" width=100 alt="@deermichel">  | Micha Hanselmann [@deermichel](https://github.com/deermichel) | Member | CET (Prague) |
 | <img src="https://github.com/raisinten.png" width=100 alt="@raisinten">  | Darshan Sen [@raisinten](https://github.com/raisinten) | Member | IST (Kolkata) |
 
-## Current Objective and Key Results
-
-**Objective:** Save expensive human time by offloading work to inexpensive computers.
-
-**Key Results:**
-* Reduce time-to-first-green, and time-to-all-greens in development.
-* Reduce number of times tests need to be re-run.
-* Reduce time to generate and deploy release builds.
-
 ## Areas of Responsibility
 
 * Releasing Electron according to schedule
@@ -71,24 +62,3 @@ This is done primarily to ensure that there are no open avenues of compromise fo
 * **Sync Meeting** 1 hour each Wednesday, alternating between two times: [16:30 UTC](https://duckduckgo.com/?q=16%3A30+UTC&ia=answer) and [23:00 UTC](https://duckduckgo.com/?q=23%3A00+UTC&ia=answer).
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).
-
-## Current Objective and Key Results
-
-**Objective:**
-
-Reduce frustrations of major app consumers
-
-**Key Results:**
-
-* Lower the number of regressions experienced in major release lines.	
-* Reduce time to discovering regressions in major release lines.
-* Increase number of apps testing against the major release line in beta.
-* Improved quality and quantity of communication around release-related information.
-
-**Objective:**
-
-Save expensive humans time
-
-**Key Results:**
-
-* Make a person’s worth of time appear.

--- a/wg-security/README.md
+++ b/wg-security/README.md
@@ -17,20 +17,6 @@ incidents, and oversees rollout of fixes.
 | <img src="https://github.com/belenko.png" width=100 alt="@belenko">  | Andrey Belenko [@belenko](https://github.com/belenko) | Member | CET (Prague) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PST |
 
-## Current Objective and Key Results
-**Objective:**
-
-Electron is used/trusted by organizations with enterprise and corporate-high-security environments.
-
-**Key Results:**
-1. Increase adoption of Electron security best-practices & tooling in AFP and **partner applications**
-2. Increase engagement of website security documentation (i.e. MOAR pageviews)
-3. Increase **measurable security** for self-identified enterprise apps.
-
-* _Partner Applications_: an app reporting feedback to Electron but outside the AFP
-* _AFP_: App Feedback Program
-* _measurable security_: an audit tool like https://github.com/doyensec/electronegativity, or self-report
-
 ## Areas of Responsibility
 
 * The reporting address: security@electronjs.org


### PR DESCRIPTION
As discussed at the 2022 summit, these "current" OKRs are out of date and not serving any purpose.