### PR TITLE
docs: update supported versions link in end-of-life playbook

### DIFF
--- a/playbooks/responses/end-of-life.md
+++ b/playbooks/responses/end-of-life.md
@@ -5,7 +5,7 @@ action:
 
 Thank you for reaching out!
 
-The version of Electron reported in this issue has reached end-of-life and is [no longer supported](https://www.electronjs.org/docs/tutorial/support#supported-versions), so this issue will be closed.
+The version of Electron reported in this issue has reached end-of-life and is [no longer supported](https://www.electronjs.org/docs/latest/tutorial/electron-timelines#timeline), so this issue will be closed.
 
 If you're still experiencing this issue on a [supported version](https://www.electronjs.org/releases/stable) of Electron, please file a new issue for that version of Electron.
 


### PR DESCRIPTION
this link has moved, so update it here.