### PR TITLE
docs: add wg-infra readme

### DIFF
--- a/wg-infra/README.md
+++ b/wg-infra/README.md
@@ -1,0 +1,42 @@
+# Infrastructure WG
+
+Oversees all infrastructure, bots, automation, services and systems that support the Electron maintainers group.
+
+## Membership
+
+| Avatar | Name | Role | Time Zone |
+| -------------------------------------------|----------------------|----------------------------| -------- |
+| <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |
+| <img src="https://github.com/codebytere.png" width=100 alt="@codebytere">  | Shelley Vohr [@codebytere](https://github.com/codebytere) | Member | CET (Berlin) |
+| <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | ET (Harrisburg) |
+
+## Areas of Responsibility
+
+* Cloud Services
+  * Heroku
+  * AWS
+  * Azure
+  * GitHub
+  * Grafana
+  * Goma
+  * CircleCI
+  * Appveyor
+  * Sentry
+  * Slack
+  * 1Password
+  * NPM
+* Electron Bots
+* Permission and Access Controls (Sheriff, etc.)
+
+## Rules for Membership
+
+In order to join the Infrastructure Working Group, an aspiring member must:
+
+1. Show a continued interest in the systems this group is responsible for
+2. Be a long-trusted member of the maintainers community
+
+## WG Removal Policy
+
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+
+This is done primarily to ensure that there are no open avenues of compromise for the project given that the Infrastructure WG confers notable permissions.

--- a/wg-infra/README.md
+++ b/wg-infra/README.md
@@ -38,6 +38,6 @@ In order to join the Infrastructure Working Group, an aspiring member must:
 
 ## WG Removal Policy
 
-If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.  The vote must pass with a majority (>50% of sitting members excluding the subject of the vote).
 
 This is done primarily to ensure that there are no open avenues of compromise for the project given that the Infrastructure WG confers notable permissions.

--- a/wg-infra/README.md
+++ b/wg-infra/README.md
@@ -27,6 +27,11 @@ Oversees all infrastructure, bots, automation, services and systems that support
   * NPM (Including CFA)
 * Electron Bots - Specifically the hosting systems and deployments, actual bot implementations may be owned by other working groups.
 * Permission and Access Controls (Sheriff, etc.)
+* Maintainer tooling
+  * [`electron/build-tools`](https://github.com/electron/build-tools)
+  * [`electron/build-images`](https://github.com/electron/build-images)
+  * [`electron/build-tools-installer`](https://github.com/electron/build-tools-installer)
+  * [`electron/sheriff`](https://github.com/electron/sheriff)
 
 ## Rules for Membership
 

--- a/wg-infra/README.md
+++ b/wg-infra/README.md
@@ -24,8 +24,8 @@ Oversees all infrastructure, bots, automation, services and systems that support
   * Sentry
   * Slack
   * 1Password
-  * NPM
-* Electron Bots
+  * NPM (Including CFA)
+* Electron Bots - Specifically the hosting systems and deployments, actual bot implementations may be owned by other working groups.
 * Permission and Access Controls (Sheriff, etc.)
 
 ## Rules for Membership

--- a/wg-infra/README.md
+++ b/wg-infra/README.md
@@ -34,6 +34,7 @@ In order to join the Infrastructure Working Group, an aspiring member must:
 
 1. Show a continued interest in the systems this group is responsible for
 2. Be a long-trusted member of the maintainers community
+3. TBD, this group is still forming primarily in an organizational capacity, when the initial storm is over this list will be updated with a more accurate set of requirements
 
 ## WG Removal Policy
 


### PR DESCRIPTION
As discussed at Summit, this lays the groundwork for a new place for docs, policies and a new organizational structure around the things this working group will own that were previously "unowned"