### PR TITLE
docs: update AWG readme

### DIFF
--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -16,7 +16,7 @@ The initial group members consist of management from Microsoft, and Slack whose 
 
 ## Areas of Responsibility
 
-The AWG aims to ensure the collective health of the maintainers and working groups, while additionally offering assistance as necessary through means that may not fall on any existing working group, such as a mechanism for escalation.
+The AWG aims to ensure the collective health of the maintainers and working groups, while offering support as necessary through means that may not fall on any existing working group, such as a mechanism for escalation.
 
 *The AWG should not make individual technical decisions.*
 

--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -7,14 +7,6 @@ To avoid the AWG becoming the _superpower_ group,
 members should not participate in other technical working groups.
 The initial group members consist of management from Microsoft, and Slack whose teams contain full-time Electron contributors.
 
-In order to have a balance of voices,
-the group should also seek to add a representative from the rest of governance,
-and a non-governance member who can represent the community at-large.
-
-*The AWG should not make individual technical decisions.*
-
-It is important that other working groups have autonomy and agency to fulfill their responsibilities.
-
 ## Membership
 
 | Avatar | Name | Role | Time Zone |
@@ -22,15 +14,17 @@ It is important that other working groups have autonomy and agency to fulfill th
 | <img src="https://github.com/PlaineKevin.png" width=100 alt="@PlaineKevin">  | Kevin Nguyen [@PlaineKevin](https://github.com/PlaineKevin) | Chair | PT (Los Angeles) |
 | <img src="https://github.com/groundwater.png" width=100 alt="@groundwater">  | Jacob Groundwater [@groundwater](https://github.com/groundwater) | Member | PT (San Francisco) |
 
+## Areas of Responsibility
+
+The AWG aims to ensure the collective health of the maintainers and working groups, while additionally offering assistance as necessary through means that may not fall on any existing working group, such as a mechanism for escalation.
+
+*The AWG should not make individual technical decisions.*
+
+It is important that other working groups have autonomy and agency to fulfill their responsibilities.
+
 ### Open Roles
 
-- Governance Representative
-  
-  The *Governance Representative* is decided by the other working groups. They can be replaced any time, at the discretion of the other working groups.
-- Community Representative
-  
-  The *Community Representative* is a non-governance person.
-  The process for electing this person has not yet been defined.
+The AWG is open to welcoming new members. Please note that as a prerequisite, interested parties must manage a substantial investment in the project, including supporting teams that contain regular Electron contributors
 
 
 


### PR DESCRIPTION
As requested at the summit, made some updates to bring the AWG readme up to date with the current state. Notably, I removed the note about the two additional members (the governance rep and the community rep) as well as added a bit more color to our responsibilities. Let me know if it's still too vague or if you have any concerns or additions.