### PR TITLE
feat: add new-npm-package script to wg-infra

### DIFF
--- a/wg-infra/scripts/README.md
+++ b/wg-infra/scripts/README.md
@@ -1,0 +1,22 @@
+# Infrastructure Scripts
+
+The scripts in this directory are used by the Infrastructure WG to perform common actions.  Descriptions and
+usage for each command is included below.
+
+Most scripts in this directory rely on the [1Password CLI](https://developer.1password.com/docs/cli/get-started/)
+working and being appropriately configured.  While running these scripts 1Password may prompt for authorization.
+
+## `new-npm-package`
+
+### Details
+
+Creates or claims a new npm package in the `@electron` scope for usage with CFA. Creates the npm package if
+it does not exist and then moves it to the `cfa` team and revokes all other users access before finally
+enforcing 2FA publishes on the package.
+
+### Usage
+
+```bash
+# Create or claim the @electron/get package
+new-npm-package get
+```

--- a/wg-infra/scripts/new-npm-package.sh
+++ b/wg-infra/scripts/new-npm-package.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Colors
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Variables
+PACKAGE_NAME=@electron/$1
+PRETTY_PACKAGE=$CYAN\"$PACKAGE_NAME\"$NC
+
+echo -e Creating or claiming the npm package $PRETTY_PACKAGE
+read -p "Do you want to proceed? (yes/no) " yn
+
+case $yn in 
+	yes ) echo OK, claiming now;;
+	no ) echo Exiting...;
+		exit;;
+	* ) echo Invalid response;
+		exit 1;;
+esac
+
+temp_dir=$(mktemp -d "$TMPDIR/claim.XXXXXX")
+touch "$temp_dir/.npmrc"
+touch "$temp_dir/package.json"
+
+tee -a "$temp_dir/.npmrc" 1>/dev/null <<EOF
+//registry.npmjs.org/:_authToken=\${NPM_TOKEN}
+EOF
+tee -a "$temp_dir/package.json" 1>/dev/null <<EOF
+{
+  "name": "$PACKAGE_NAME",
+  "version": "0.0.0"
+}
+EOF
+
+pushd $temp_dir 1>/dev/null
+
+ELECTRON_CFA_ITEM=lgrko2iptbajfhqokwhu2amsea
+ELECTRON_CFA_GENERATOR_ITEM_ID=rawdp5uvajeyfii46ixjyzrjse
+ELECTRON_ITEM=uc5oyoj7vbcbpp6wevbr7sgrky
+ELECTRON_GENERATOR_ITEM_ID=i4vqjwdlkva7nou4bwsilmorgu
+
+# Switch to the "electron" npm account
+export NPM_TOKEN=$(op item get $ELECTRON_ITEM --fields label="Auth Token")
+if [[ "$NPM_TOKEN" == "" ]]; then
+  echo 1Password CLI not configured correctly
+  exit 1
+fi
+
+# If the package does not exist, publish the fake one
+if npm show "$PACKAGE_NAME" > /dev/null; then
+  echo -e The $PRETTY_PACKAGE package already exists
+else
+  NPM_TOKEN=$NPM_TOKEN npm publish --access=public --otp=$(op item get $ELECTRON_GENERATOR_ITEM_ID --otp)
+fi
+
+# If the package doesn't have electron-cfa as an owner, add them
+echo -e '\n'✅ Granting CFA access to $PRETTY_PACKAGE
+npm access grant read-write @electron:cfa "$PACKAGE_NAME"
+
+echo -e '\n'✅ Revoking default access to $PRETTY_PACKAGE
+npm access revoke @electron:developers "$PACKAGE_NAME"
+
+# Switch to the CFA account to mess with this package
+export NPM_TOKEN=$(op item get $ELECTRON_CFA_ITEM --fields label="Auth Token")
+
+echo -e '\n'✅ Required 2FA for $PRETTY_PACKAGE
+npm access 2fa-required "$PACKAGE_NAME" --otp=$(op item get $ELECTRON_CFA_GENERATOR_ITEM_ID --otp)
+
+export NPM_TOKEN=.
+unset NPM_TOKEN
+
+popd 1>/dev/null


### PR DESCRIPTION
As in title, adds a new helper script for the infrastructure working group for making or claiming a new npm package for use with CFA.

![image](https://user-images.githubusercontent.com/6634592/196366807-31db81d2-b12a-4155-8355-38048f69802a.png)

Once this and https://github.com/continuousauth/web/pull/45 land I can write a new doc on how to set up CFA that will be **substantially** simpler than the original process courtesy of that PR and this helpful script.