### PR TITLE
refactor: charter updates - accuracy

### DIFF
--- a/charter/README.md
+++ b/charter/README.md
@@ -1,8 +1,12 @@
 # Electron Governance Charter
 
+<!--
+TODO:
+- would be cool to get some icons / art for these values for use on the website (Sam)
+  - +1 (Charles)
+-->
+
 ## Core Values
-<!-- Side note, would be cool to get some icons / art for these values for use on the website (Sam) -->
-<!-- :+1: (Charles) -->
 
 These are our core values, as voted by the maintainers, in order of importance. When in doubt, these should guide our decisions.
 
@@ -37,14 +41,15 @@ These are our core values, as voted by the maintainers, in order of importance. 
  * A _collaborator_ is active in the community, but not in governance.
  * A _participant_ is anyone who is a maintainer or collaborator.
  * A _working group_ is a group of maintainers that is formed to take responsibility for certain aspects of the Electron project. Normally these groups will meet regularly but in some cases will only meet as required to fulfill their responsibilities.
- * A [_chair_](#Leadership) leads a working group.
+ * A _chair_ is the acting leader of a working group that uses the [Rotating Chair Model](rotating-chair-model.md).
+ * A [_delegate_](#Delegation) is a chosen representative of a working group.
 
 ## Participation
 
  * [Code of Conduct](../CODE_OF_CONDUCT.md)
  * [Using Slack](../policy/slack.md)
  * [Triaging Issues](../playbooks/README.md)
-<!-- * [Using Pull Requests](FIXME: link to PR etiquette doc) -->
+ * [Using Pull Requests](../policy/pull-requests.md)
 
 ## Working Groups
 
@@ -63,7 +68,7 @@ These are our core values, as voted by the maintainers, in order of importance. 
 
 All Working Groups have these core responsibilities:
  * They shall decide for themselves, and publicly post, their rules, e.g. how decisions are made, when meetings are held, and who may attend.
- * They shall [select](#Leadership-Terms-and-Selection) a chair to [represent](#Leadership-Responsibilities) the group.
+ * They shall choose a model of work to support reaching the working group's goals.
  * They shall keep meeting notes, including agenda items, discussion points, and outcomes for everyone to review.
  * They shall be collaborative and work [in good faith](#Core-Values) with other Working Groups.
 
@@ -73,46 +78,11 @@ Group members live and work in many time zones, so synchronous meetings aren't a
 
 Members should have the opportunity to read a summary of the meeting and share pertinent opinions before voting is finalized. Groups may use [Doodle](https://doodle.com) or a similar mechanism to decide on meeting times that are convenient for the members.
 
-### Leadership
+### Delegation
 
-#### Leadership Terms and Selection
+Delegates have responsibilities to their Working Group: they represent the collective will of that group to others.
 
-Each Working Group shall be led by a Chair.
-
-The Chair shall have a four month term. A person is eligible to chair the Working Group if and only if they satisfy all conditions:
-  1. They wish to serve as Chair.
-  1. They are a member of the Working Group.
-  1. They are not the chair of more than one other Working Group. (i.e. One person may chair a maximum of two Working Groups at a time)
-  1. They have not Chaired that Working Group more recently than any eligible member. (Think of “shuffle play” music)
-
-A Working Group can not have the same chair twice in a row. If the only person willing to serve next is the current chair, this is a sign of an unhealthy group and should be addressed by the Administrative Working Group.
-
-The group will make a reasonable effort to notify potential candidates that a new term is coming so that interested parties can declare their eligibility.
-
-A chair is selected at random from the set of eligible candidates. The candidates and selection are to be documented and made public.
-
-A chair's term does not need to begin at the same time as other chairs' terms.
-
-If a chair steps down, a new one is selected and a new four-month term begins (i.e., interim Chairs are not needed)
-
-#### Leadership Responsibilities
-
-Chairs have responsibilities to their Working Group: they represent the collective will of that group to others.
-
-Chairs have responsibilities to their parent Working Group: they ensure that their Working Group is carrying out its mission.
-
-Chairs have responsibility to all participants in transparently reporting the group's activity.
-
-Chairs also have the following regular duties within their Working Groups:
-* Collect agenda items prior to each meeting to ensure a smooth and focused Working Group meeting.
-* Ensure that the Working Group is notified of the agenda for the meeting in a timely manner advance of the meeting.
-* Attend and lead each Working Group meeting.
-    * If the Chair is unable to attend a given meeting, they should delegate a pre-appointed person to lead the meeting in their stead.
-* Ensure meeting notes are uploaded to the `governance` repo in the Working Group's respective sub-folder following each meeting.
-* Check into persistent issues present on a given Working Group's repositories of responsibility (ex. bot failures)
-* Ensure that the WG roster list is an accurate reflection of current member activity.
-
-In addition to these responsibilities, a Chair may have additional responsibilities specific to their Working Group.
+Delegates are [chosen](#Reaching-Agreement) by the members of their Working Group.
 
 ### Reaching Agreement
 
@@ -120,7 +90,7 @@ If an issue affects only one Working Group, that group can make decisions [on it
 
 If an issue affects more than one Working Group, those groups are encouraged to work towards agreement together.
 
-If agreement cannot be reached, the chairs of all Working Groups shall try to decide the matter with a vote. A reasonable effort shall be made to let all interested chairs participate in this, but any chair may abstain.
+If agreement cannot be reached, delegates from all Working Groups shall try to decide the matter with a vote. A reasonable effort shall be made to let all interested working groups participate in this, but any working group may decide abstain.
 
 If agreement still cannot be reached, the issue may be brought to the Administrative Working Group, which has final say.
 
@@ -158,6 +128,5 @@ it is expected that the AWG abstains from casting individual technical decisions
 The AWG should principally serve as a _circuit breaker_.
 If a delegate working group is failing to meet its responsibilities, the AWG may intervene up to and including altering group members, or altering the groups authority, responsibilities, or existence.
 
-**Authors note:**
-
-> The current Electorate/AWG mix places almost all the power in the hands of a few large corporations at the outset. While not ideal to many, this was chosen because it represents today's status-quo. The choice to delay defining an Electorate was made to _ensure_ it was not rushed, and that we have time to balance project stakeholders large and small.
+> **Authors note:**
+> The current Electorate/AWG mix places almost all the power in the hands of a few large corporations at the outset. While not ideal to many, this was chosen because it represents the present status-quo, as of writing. The choice to delay defining an Electorate was made to _ensure_ it was not rushed, and that we have time to balance project stakeholders large and small.

--- a/charter/README.md
+++ b/charter/README.md
@@ -40,9 +40,9 @@ These are our core values, as voted by the maintainers, in order of importance. 
  * A _maintainer_ is anyone who plays an active role in governance.
  * A _collaborator_ is active in the community, but not in governance.
  * A _participant_ is anyone who is a maintainer or collaborator.
- * A _working group_ is a group of maintainers that is formed to take responsibility for certain aspects of the Electron project. Normally these groups will meet regularly but in some cases will only meet as required to fulfill their responsibilities.
- * A _chair_ is the acting leader of a working group that uses the [Rotating Chair Model](rotating-chair-model.md).
- * A [_delegate_](#Delegation) is a chosen representative of a working group.
+ * A _Working Group_ is a group of maintainers that is formed to take responsibility for certain aspects of the Electron project. Normally these groups will meet regularly but in some cases will only meet as required to fulfill their responsibilities.
+ * A _chair_ is the acting leader of a Working Group that uses the [Rotating Chair Model](rotating-chair-model.md).
+ * A [_delegate_](#Delegation) is a chosen representative of a Working Group.
 
 ## Participation
 
@@ -68,21 +68,23 @@ These are our core values, as voted by the maintainers, in order of importance. 
 
 All Working Groups have these core responsibilities:
  * They shall decide for themselves, and publicly post, their rules, e.g. how decisions are made, when meetings are held, and who may attend.
- * They shall choose a model of work to support reaching the working group's goals.
+ * They shall choose a model of work to support reaching the Working Group's goals.
  * They shall keep meeting notes, including agenda items, discussion points, and outcomes for everyone to review.
  * They shall be collaborative and work [in good faith](#Core-Values) with other Working Groups.
 
 ### Meetings
 
-Group members live and work in many time zones, so synchronous meetings aren't always possible. No one should feel like they need to attend a meeting at an inconvenient time for their voice to be heard. If a group is to make a decision by voting, it shall make a reasonable effort to inform all members about the vote and give them a chance to vote outside of the meeting itself.
+Group members live and work in many timezones, so synchronous meetings aren't always possible. No one should feel like they need to attend a meeting at an inconvenient time for their voice to be heard. If a group is to make a decision by voting, it shall make a reasonable effort to inform all members about the vote and give them a chance to vote outside of the meeting itself.
 
-Members should have the opportunity to read a summary of the meeting and share pertinent opinions before voting is finalized. Groups may use [Doodle](https://doodle.com) or a similar mechanism to decide on meeting times that are convenient for the members.
+Working Groups with members across diverse timezones should make an effort to include all members in decisions, votes, and meetings. Such Working Groups may consider using third-party tools for this purpose, like coordinating meeting times that work for members in different timezones.
+
+Members should have the opportunity to read a summary of the meeting and share pertinent opinions before voting is finalized.
 
 ### Delegation
 
 Delegates have responsibilities to their Working Group: they represent the collective will of that group to others.
 
-Delegates are [chosen](#Reaching-Agreement) by the members of their Working Group.
+Delegates are [chosen](#Reaching-Agreement) by the members of their Working Group, either when the need for one arises or for a short period of time not longer than four weeks when a delegate may be needed multiple times in rapid succession.
 
 ### Reaching Agreement
 
@@ -90,21 +92,17 @@ If an issue affects only one Working Group, that group can make decisions [on it
 
 If an issue affects more than one Working Group, those groups are encouraged to work towards agreement together.
 
-If agreement cannot be reached, delegates from all Working Groups shall try to decide the matter with a vote. A reasonable effort shall be made to let all interested working groups participate in this, but any working group may decide abstain.
+If agreement cannot be reached, delegates from all involved Working Groups must try to decide the matter with a vote. A reasonable effort must be made to let all interested Working Groups participate in this, but any Working Group may choose abstain.
 
-If agreement still cannot be reached, the issue may be brought to the Administrative Working Group, which has final say.
+If agreement still cannot be reached, the issue may be brought to the Administrative Working Group which has final say.
 
-Regardless of how agreement is reached, the participating groups shall make a reasonable effort to record and post their decisions for transparency.
+Regardless of how agreement is reached, the participating groups must make a reasonable effort to record and post their decisions for transparency.
 
 # Electorate
 
-The **Electorate** is the body who holds the ability to alter the charter and appoint members of the administrative working group.
+The **Electorate** is the body who holds the ability to alter the charter and appoint members of the [Administrative Working Group](#Administrative-Working-Group).
 
-Designing a new Electorate is currently out-of-scope for this charter.
-Instead we make the implicit status-quo explicit.
-GitHub will act as the Electorate with the intention of overseeing a replacement after the current governance is rolled out.
-
-We want an Electorate which can balance several factors:
+The Electorate should try to balance several factors in its composition of members:
 
 1. new contributors
 2. long-time contributors
@@ -112,8 +110,9 @@ We want an Electorate which can balance several factors:
 4. financial contributions
 5. tenured contributions
 
-There is no explicit timeline around this,
-but this charter expects it to be addressed in a reasonable timeframe.
+Initially, the Electorate was GitHub. Designing a new Electorate is still out-of-scope for this charter. Instead, we will make the implicit status-quo explicit: the Administrative Working Group is comprised of managers from Microsoft and Slack.
+
+There is no explicit timeline around designing a better electorate, but this charter expects it to be addressed in a reasonable timeframe.
 
 ## Administrative Working Group
 
@@ -121,12 +120,12 @@ See the [Working Group README](../wg-administrative)
 
 The Administrative Working Group (AWG) is chartered with the responsibility to ensure governance is serving the best needs of the project and community.
 The AWG has authority to act on the project, granted by the electorate.
-The AWG in turn delegates its authority to all other working groups.
+The AWG in turn delegates its authority to all other Working Groups.
 
 To prevent the AWG from becoming the sole political power of the project,
-it is expected that the AWG abstains from casting individual technical decisions that are the responsibility of other working groups.
+it is expected that the AWG abstains from casting individual technical decisions that are the responsibility of other Working Groups.
 The AWG should principally serve as a _circuit breaker_.
-If a delegate working group is failing to meet its responsibilities, the AWG may intervene up to and including altering group members, or altering the groups authority, responsibilities, or existence.
+If a delegate Working Group is failing to meet its responsibilities, the AWG may intervene up to and including altering group members, or altering the groups authority, responsibilities, or existence.
 
 > **Authors note:**
 > The current Electorate/AWG mix places almost all the power in the hands of a few large corporations at the outset. While not ideal to many, this was chosen because it represents the present status-quo, as of writing. The choice to delay defining an Electorate was made to _ensure_ it was not rushed, and that we have time to balance project stakeholders large and small.

--- a/charter/rotating-chair-model.md
+++ b/charter/rotating-chair-model.md
@@ -1,0 +1,57 @@
+# Rotating Chair Model
+
+The Rotating Chair Model is a model of a working group that uses a chosen leader to push forward the working group's goals. The chosen leader is regularly replaced with a new one, creating a "rotation" of leadership among the working group's members. This rotation promotes knowledge sharing and distribution of work duties among members.
+
+## Working Group Responsibilities
+
+A Working Group that uses the Rotating Chair Model has an additional core responsibility:
+* They shall [select](#Chair-Terms-and-Selection) a rotating chair to [represent](#Chair-Responsibilities) the group.
+
+## Chair Terms and Selection
+
+Each Working Group shall be led by a Chair.
+
+The Chair has a term that is written in the Working Group's own charter. By default, that term is four months.
+
+A person is eligible to chair the Working Group if and only if they satisfy all conditions:
+1. They wish to serve as chair.
+2. They are a member of the Working Group.
+3. They are not the chair of more than one other Working Group.
+    * i.e. One person may chair a maximum of two Working Groups at a time
+4. They have not been the chair of that Working Group more recently than any eligible member.
+    * i.e. Only the eligible members that have least recently (or never) been the chair of that Working Group are able to be chosen.
+
+If there is nobody willing or able to serve as chair, then the Administrative Working Group should be notified for assistance. The AWG can optionally choose to make a delegate from the AWG a temporary chair for the Working Group with the primary goal of reenabling the Working Group's ability to sustain its own chair rotation.
+
+The group will make a reasonable effort to notify potential candidates that a new term is coming so that interested parties can declare their eligibility.
+
+A chair is selected at random from the set of eligible candidates. The candidates and selection are to be documented and made public.
+
+A chair's term does not need to begin at the same time as other working groups.
+
+If a chair steps down, a new one is selected and a new term begins (i.e., interim chairs are not needed)
+
+## Chair Responsibilities
+
+Chairs have responsibilities to their parent Working Group: they ensure that their Working Group is carrying out its mission.
+
+Chairs have responsibility to all participants in transparently reporting the group's activity.
+
+Chairs also have the following regular duties within their Working Groups:
+* Collect agenda items prior to each meeting to ensure a smooth and focused Working Group meeting.
+* Ensure that the Working Group is notified of the agenda for the meeting in a timely manner advance of the meeting.
+* Attend and lead each Working Group meeting.
+    * If the chair is unable to attend a given meeting, they should appoint another member to lead the meeting in their stead.
+* Ensure meeting notes are uploaded to the `governance` repo in the Working Group's respective sub-folder following each meeting.
+* Check into persistent issues present on a given Working Group's repositories of responsibility (ex. bot failures)
+* Ensure that the WG roster list is an accurate reflection of current member activity.
+
+In addition to these responsibilities, a chair may have additional responsibilities specific to their Working Group.
+
+## Is the Rotating Chair Model Right For My Working Group?
+
+(This section is non-normative.)
+
+The following advice and considerations can help a new Working Group decide whether the Rotating Chair Model is a good fit:
+
+* 

--- a/charter/rotating-chair-model.md
+++ b/charter/rotating-chair-model.md
@@ -1,15 +1,13 @@
 # Rotating Chair Model
 
-The Rotating Chair Model is a model of a working group that uses a chosen leader to push forward the working group's goals. The chosen leader is regularly replaced with a new one, creating a "rotation" of leadership among the working group's members. This rotation promotes knowledge sharing and distribution of work duties among members.
+The Rotating Chair Model is a model of a Working Group that appoints a leader to push forward the Working Group's goals. The leader is regularly replaced with a new one, creating a "rotation" of leadership among the Working Group's members. This rotation promotes knowledge sharing and distribution of work duties among members.
 
 ## Working Group Responsibilities
 
 A Working Group that uses the Rotating Chair Model has an additional core responsibility:
-* They shall [select](#Chair-Terms-and-Selection) a rotating chair to [represent](#Chair-Responsibilities) the group.
+* They shall [select](#Chair-Terms-and-Selection) a rotating chair to [lead](#Chair-Responsibilities) the group and ensure the Working Group's goals are fulfilled.
 
 ## Chair Terms and Selection
-
-Each Working Group shall be led by a Chair.
 
 The Chair has a term that is written in the Working Group's own charter. By default, that term is four months.
 
@@ -21,19 +19,19 @@ A person is eligible to chair the Working Group if and only if they satisfy all 
 4. They have not been the chair of that Working Group more recently than any eligible member.
     * i.e. Only the eligible members that have least recently (or never) been the chair of that Working Group are able to be chosen.
 
-If there is nobody willing or able to serve as chair, then the Administrative Working Group should be notified for assistance. The AWG can optionally choose to make a delegate from the AWG a temporary chair for the Working Group with the primary goal of reenabling the Working Group's ability to sustain its own chair rotation.
+If there is nobody willing or able to serve as chair, then the Administrative Working Group should be notified for assistance. The AWG can optionally choose to make a delegate from the AWG a temporary chair for the Working Group with the primary goal of reenabling the Working Group to sustain its own chair rotation.
 
 The group will make a reasonable effort to notify potential candidates that a new term is coming so that interested parties can declare their eligibility.
 
 A chair is selected at random from the set of eligible candidates. The candidates and selection are to be documented and made public.
 
-A chair's term does not need to begin at the same time as other working groups.
+A chair's term does not need to begin at the same time as other Working Groups.
 
-If a chair steps down, a new one is selected and a new term begins (i.e., interim chairs are not needed)
+If a chair steps down, a new one is selected and a new term begins (i.e., interim chairs are not needed).
 
 ## Chair Responsibilities
 
-Chairs have responsibilities to their parent Working Group: they ensure that their Working Group is carrying out its mission.
+Chairs have responsibilities to their Working Group: they ensure that their Working Group is carrying out its mission.
 
 Chairs have responsibility to all participants in transparently reporting the group's activity.
 
@@ -41,12 +39,12 @@ Chairs also have the following regular duties within their Working Groups:
 * Collect agenda items prior to each meeting to ensure a smooth and focused Working Group meeting.
 * Ensure that the Working Group is notified of the agenda for the meeting in a timely manner advance of the meeting.
 * Attend and lead each Working Group meeting.
-    * If the chair is unable to attend a given meeting, they should appoint another member to lead the meeting in their stead.
-* Ensure meeting notes are uploaded to the `governance` repo in the Working Group's respective sub-folder following each meeting.
-* Check into persistent issues present on a given Working Group's repositories of responsibility (ex. bot failures)
-* Ensure that the WG roster list is an accurate reflection of current member activity.
+    * If the chair is unable to attend a meeting, they should appoint another member to lead the meeting in their stead.
+* Ensure meeting notes are uploaded to the `governance` repo in the Working Group's respective subdirectory following each meeting.
+* Check into persistent issues present on their Working Group's repositories of responsibility (ex. bot failures).
+* Ensure that the WG roster list accurately reflects current membership.
 
-In addition to these responsibilities, a chair may have additional responsibilities specific to their Working Group.
+In addition to these general responsibilities, a chair may have additional responsibilities specific to their Working Group written in their charter.
 
 ## Is the Rotating Chair Model Right For My Working Group?
 
@@ -54,4 +52,9 @@ In addition to these responsibilities, a chair may have additional responsibilit
 
 The following advice and considerations can help a new Working Group decide whether the Rotating Chair Model is a good fit:
 
-* 
+* Does your Working Group have many different tasks that can be assigned to different members?
+  * A Rotating Chair may provide value as someone who coordinates tasks and ensures that other members have the support to carry their tasks to completion.
+* Does your Working Group regularly cycle between members for completing a single, focused work task?
+  * The Rotation Chair Model may provide value as a standardized and reliable ritual for choosing the next member and ensuring all members can learn and get the opportunity to complete work.
+* Does your Working Group need to be able to reliably make important decisions and resolve split positions between members?
+  * A Rotating Chair may provide value as a tie-breaker vote when members are split on an issue, while still making it possible for that crucial vote to belong to any member.


### PR DESCRIPTION
This PR sets out to update the charter with the goal of improving its **Accuracy** in regards to how governance has been working in practice. Major changes are as follows:

* The Rotating Chair Model was refactored out (but not changed significantly) to allow working groups to choose their own model of accomplishing work.
  * This is supported by working groups where the purpose of a chair wasn't providing value.
  * One modification made to the Rotating Chair Model was the ability for a working group to decide its own term length for the chair.
* The concept of a *Delegate* was added to fulfill the governance-related roles that were previously expected by the chair, which not every working group may now have.
* Minor fix-ups to links and comments were made.

Let me know if anything else should be changed or if any of these changes don't fit with our model of governance! I would be more than happy to receive everyone's feedback here. 😊