### PR TITLE
Prefer using milliseconds for time measurement

### DIFF
--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -111,6 +111,13 @@ If you need to express a state which is a combination of properties, which might
 
 See https://w3ctag.github.io/design-principles/#string-constants.
 
+### Use milliseconds for time measurement
+If you are designing an API that accepts a time measurement, express the time measurement in milliseconds.
+
+Even if seconds (or some other time unit) are more natural in the domain of an API, sticking with milliseconds ensures that APIs are interoperable with one another. This means that authors don’t need to convert values used in one API to be used in another API, or keep track of which time unit is needed where.
+
+https://w3ctag.github.io/design-principles/#milliseconds
+
 ## Classes
 
 ### Use a class's name as the module name


### PR DESCRIPTION
https://github.com/electron/electron/pull/35987 introduces an API which accepts a time measurement. We should set a standard for all APIs going forward.

Using the [web platform's design principles](https://w3ctag.github.io/design-principles/#milliseconds) as a guide, I'm proposing we use milliseconds.