### PR TITLE
chore: enable remaining linting rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,14 +1,3 @@
 {
-  "extends": "@electron/lint-roller/configs/markdownlint.json",
-  "blanks-around-fences": false,
-  "blanks-around-headings": false,
-  "blanks-around-headers": false,
-  "blanks-around-lists": false,
-  "fenced-code-language": false,
-  "ol-prefix": false,
-  "no-multiple-blanks": false,
-  "no-shortcut-reference-links": false,
-  "no-trailing-spaces": false,
-  "ul-indent": false,
-  "ul-style": false
+  "extends": "@electron/lint-roller/configs/markdownlint.json"
 }

--- a/charter/README.md
+++ b/charter/README.md
@@ -37,23 +37,23 @@ These are our core values, as voted by the maintainers, in order of importance. 
 
 ## Definitions
 
- * A _maintainer_ is anyone who plays an active role in governance.
- * A _collaborator_ is active in the community, but not in governance.
- * A _participant_ is anyone who is a maintainer or collaborator.
- * A _Working Group_ is a group of maintainers that is formed to take responsibility for certain aspects of the Electron project. Normally these groups will meet regularly but in some cases will only meet as required to fulfill their responsibilities.
- * A _chair_ is the acting leader of a Working Group that uses the [Rotating Chair Model](rotating-chair-model.md).
- * A [_delegate_](#delegation) is a chosen representative of a Working Group.
+* A _maintainer_ is anyone who plays an active role in governance.
+* A _collaborator_ is active in the community, but not in governance.
+* A _participant_ is anyone who is a maintainer or collaborator.
+* A _Working Group_ is a group of maintainers that is formed to take responsibility for certain aspects of the Electron project. Normally these groups will meet regularly but in some cases will only meet as required to fulfill their responsibilities.
+* A _chair_ is the acting leader of a Working Group that uses the [Rotating Chair Model](rotating-chair-model.md).
+* A [_delegate_](#delegation) is a chosen representative of a Working Group.
 
 ## Participation
 
- * [Code of Conduct](../CODE_OF_CONDUCT.md)
- * [Using Slack](../policy/slack.md)
- * [Triaging Issues](../playbooks/README.md)
- * [Using Pull Requests](../policy/pull-requests.md)
+* [Code of Conduct](../CODE_OF_CONDUCT.md)
+* [Using Slack](../policy/slack.md)
+* [Triaging Issues](../playbooks/README.md)
+* [Using Pull Requests](../policy/pull-requests.md)
 
 ## Working Groups
 
-| Working Group  | Repo | Description | 
+| Working Group  | Repo | Description |
 |:---------------|:------|-------------|
 | Administrative | [wg-administrative](../wg-administrative) | Administrates Governance |
 | Community      | [wg-community-safety](../wg-community-safety/) | Handles Code of Conduct issues |
@@ -67,10 +67,11 @@ These are our core values, as voted by the maintainers, in order of importance. 
 ### Responsibilities
 
 All Working Groups have these core responsibilities:
- * They shall decide for themselves, and publicly post, their rules, e.g. how decisions are made, when meetings are held, and who may attend.
- * They shall choose a model of work to support reaching the Working Group's goals.
- * They shall keep meeting notes, including agenda items, discussion points, and outcomes for everyone to review.
- * They shall be collaborative and work [in good faith](#core-values) with other Working Groups.
+
+* They shall decide for themselves, and publicly post, their rules, e.g. how decisions are made, when meetings are held, and who may attend.
+* They shall choose a model of work to support reaching the Working Group's goals.
+* They shall keep meeting notes, including agenda items, discussion points, and outcomes for everyone to review.
+* They shall be collaborative and work [in good faith](#core-values) with other Working Groups.
 
 ### Meetings
 

--- a/charter/rotating-chair-model.md
+++ b/charter/rotating-chair-model.md
@@ -5,6 +5,7 @@ The Rotating Chair Model is a model of a Working Group that appoints a leader to
 ## Working Group Responsibilities
 
 A Working Group that uses the Rotating Chair Model has an additional core responsibility:
+
 * They shall [select](#chair-terms-and-selection) a rotating chair to [lead](#chair-responsibilities) the group and ensure the Working Group's goals are fulfilled.
 
 ## Chair Terms and Selection
@@ -12,6 +13,7 @@ A Working Group that uses the Rotating Chair Model has an additional core respon
 The Chair has a term that is written in the Working Group's own charter. By default, that term is four months.
 
 A person is eligible to chair the Working Group if and only if they satisfy all conditions:
+
 1. They wish to serve as chair.
 2. They are a member of the Working Group.
 3. They are not the chair of more than one other Working Group.
@@ -36,10 +38,11 @@ Chairs have responsibilities to their Working Group: they ensure that their Work
 Chairs have responsibility to all participants in transparently reporting the group's activity.
 
 Chairs also have the following regular duties within their Working Groups:
+
 * Collect agenda items prior to each meeting to ensure a smooth and focused Working Group meeting.
 * Ensure that the Working Group is notified of the agenda for the meeting in a timely manner advance of the meeting.
 * Attend and lead each Working Group meeting.
-    * If the chair is unable to attend a meeting, they should appoint another member to lead the meeting in their stead.
+  * If the chair is unable to attend a meeting, they should appoint another member to lead the meeting in their stead.
 * Ensure meeting notes are uploaded to the `governance` repo in the Working Group's respective subdirectory following each meeting.
 * Check into persistent issues present on their Working Group's repositories of responsibility (ex. bot failures).
 * Ensure that the WG roster list accurately reflects current membership.

--- a/playbooks/code-of-conduct-violations.md
+++ b/playbooks/code-of-conduct-violations.md
@@ -13,9 +13,9 @@ For first offenses, the process is:
 Violation text:
 
 ```markdown
-[[at-mention]] your comment was deleted as a violation of the {{project code of conduct link}} as it
-[[was insulting or derogatory/contained sexualized content/is considered harassment/published others'
-personal information/is unprofessional conduct]]. You may consider this an official warning.
+{{at-mention}} your comment was deleted as a violation of the {{project code of conduct link}} as it
+{{was insulting or derogatory/contained sexualized content/is considered harassment/published others'
+personal information/is unprofessional conduct}}. You may consider this an official warning.
 ```
 
 ## More than warnings

--- a/playbooks/issue-triage.md
+++ b/playbooks/issue-triage.md
@@ -95,50 +95,60 @@ This section outlines several common scenarios, and the responses and labels we 
 #### Low Quality/Spam
 
 Issue did not fill out the issue template:
-  * Reply with [`needs-template` response](responses/needs-template.md)
+
+* Reply with [`needs-template` response](responses/needs-template.md)
 
 Issue is asking about a third-party dependency, or app-specific JavaScript code
-  * Reply with [`not-an-issue` response](responses/not-an-issue.md)
-  * Close the issue
+
+* Reply with [`not-an-issue` response](responses/not-an-issue.md)
+* Close the issue
 
 Issue is transparently spam
-  * Close the issue (no reply needed)
+
+* Close the issue (no reply needed)
 
 #### Blocked/Needs Info
 
 Issue does not contain adequate information (i.e., no expected behavior or is on an unsupported version of Electron):
-  * Reply with [`old-version` response](responses/old-version.md), or ask for clarification on missing information
-  * Add `blocked/needs-info` label
+
+* Reply with [`old-version` response](responses/old-version.md), or ask for clarification on missing information
+* Add `blocked/needs-info` label
 
 Issue has no repro:
-  * Reply with [`blocked-needs-repro` response](responses/blocked-needs-repro.md)
-  * Add `blocked/needs-repro` label
+
+* Reply with [`blocked-needs-repro` response](responses/blocked-needs-repro.md)
+* Add `blocked/needs-repro` label
 
 ### Has Repro
 
 Issue does contain enough information and has a repro, but you as a triager don't have time to confirm the repro:
-  * Add `has-repro-gist` or `has-repro-repo` label
-  * Add `platform/*` for the affected OS (Mac/Windows/Linux/All)
-  * Add `status/reviewed` label
+
+* Add `has-repro-gist` or `has-repro-repo` label
+* Add `platform/*` for the affected OS (Mac/Windows/Linux/All)
+* Add `status/reviewed` label
 
 Issue can be reproduced!
-  * Add `status/confirmed` label
-  * Add `platform/*` for the affected OS (Mac/Windows/Linux/All) if not added
-  * If the issue affects a new version of Electron, add it to the Project Board for the **newest** affected version (i.e. if both 17-x-y and 18-x-y are affected, add it to the 18-x-y Project Board).
+
+* Add `status/confirmed` label
+* Add `platform/*` for the affected OS (Mac/Windows/Linux/All) if not added
+* If the issue affects a new version of Electron, add it to the Project Board for the **newest** affected version (i.e. if both 17-x-y and 18-x-y are affected, add it to the 18-x-y Project Board).
 
 ### Crash Report
 
 Issue details a crash, but has no repro or crash report attached:
-  * Reply with [`crash-report` response](responses/crash-report.md)
-  * Add `blocked/needs-info` label
-  * Add `crash` label
+
+* Reply with [`crash-report` response](responses/crash-report.md)
+* Add `blocked/needs-info` label
+* Add `crash` label
 
 Issue details a crash and has a crash report attached, but no repro:
-  * Add `crash` label
-  * Try running the .dmp file or report through `electron-minidump` or `electron-symbolicate`. If the crash is only a stacktrace, or if you find you need more symbol information, reply with [`crash-report` response](responses/crash-report.md)
-  * Add `status/reviewed` label
+
+* Add `crash` label
+* Try running the .dmp file or report through `electron-minidump` or `electron-symbolicate`. If the crash is only a stacktrace, or if you find you need more symbol information, reply with [`crash-report` response](responses/crash-report.md)
+* Add `status/reviewed` label
 
 Issue details a crash, and has both a crash report and a repro:
-  * Add `crash` label 
-  * Add `has-repro-gist` or `has-repro-repo` label
-  * Review the repro gist. If the crash can be reproduced, add `status/confirmed` label
+
+* Add `crash` label
+* Add `has-repro-gist` or `has-repro-repo` label
+* Review the repro gist. If the crash can be reproduced, add `status/confirmed` label

--- a/playbooks/responses/already-fixed.md
+++ b/playbooks/responses/already-fixed.md
@@ -1,3 +1,3 @@
 Thanks for reporting this!
 
-This has already been fixed in [insert PR URL here]. It is currently scheduled for release when [release number] reaches Stable.
+This has already been fixed in {{insert PR URL here}}. It is currently scheduled for release when {{release number}} reaches Stable.

--- a/playbooks/responses/crash-report.md
+++ b/playbooks/responses/crash-report.md
@@ -5,12 +5,13 @@ action:
 
 Could you please attach a crash dump to help us get more information? You can collect them by adding the following snippet to your main process code, before app.whenReady:
 
-```
+```js
 const { app, crashReporter } = require('electron')
 
 console.log(app.getPath('crashDumps'))
 crashReporter.start({ submitURL: '', uploadToServer: false })
 ```
+
 Then reproduce the crash, zip up the crash dumps directory and attach it here. I'm adding the `blocked/need-info` label until we have access to the crash dumps.
 
 Thanks in advance! Your help is appreciated.

--- a/playbooks/responses/duplicate-notification.md
+++ b/playbooks/responses/duplicate-notification.md
@@ -7,7 +7,7 @@ action:
 
 Thanks for taking the time to contribute!
 
-We noticed that this is a duplicate of [Issue URL]. You may want to subscribe there for updates.
+We noticed that this is a duplicate of {{Issue URL}}. You may want to subscribe there for updates.
 
 Because we treat our issues list as [the project team's backlog](https://en.wikipedia.org/wiki/Scrum_(software_development)#Product_backlog), we close duplicates to focus our work and not have to touch the same chunk of code for the same reason multiple times. This is also why we may mark something as duplicate that isn't an exact duplicate but is closely related.
 

--- a/playbooks/responses/first-warning.md
+++ b/playbooks/responses/first-warning.md
@@ -1,3 +1,3 @@
-[[at-mention]] your comment was [[minimized|deleted]] as a violation of [the Electron Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md). You may consider this an official warning.
+{{at-mention}} your comment was {{minimized|deleted}} as a violation of [the Electron Code of Conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md). You may consider this an official warning.
 
 **Please do not interact with the project for 24 hours.** After that, please look through your open issues and edit them to ensure they're entirely on-topic, and we can continue the discussion here about the best way to go forward.

--- a/playbooks/responses/no-response.md
+++ b/playbooks/responses/no-response.md
@@ -5,4 +5,4 @@ action:
 
 Thank you for your issue!
 
-We haven't gotten a response to our questions in our comment [insert URL here]. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.
+We haven't gotten a response to our questions in our comment {{insert URL here}}. With only the information that is currently in the issue, we don't have enough information to take action. I'm going to close this but don't hesitate to reach out if you have or find the answers we need, we'll be happy to reopen the issue.

--- a/playbooks/responses/not-an-issue.md
+++ b/playbooks/responses/not-an-issue.md
@@ -4,6 +4,6 @@ action:
  - close issue
 ---
 
-Thanks for reaching out and logging this issue! Because we treat our issues list as the team's backlog, we close issues that are questions since they don't represent a task needing to be completed. For most questions about Electron there are a lot of options. 
+Thanks for reaching out and logging this issue! Because we treat our issues list as the team's backlog, we close issues that are questions since they don't represent a task needing to be completed. For most questions about Electron there are a lot of options.
 
 Check out the [Electron community](https://www.electronjs.org/community#boilerplates). There are also a bunch of helpful people in this [Discord](https://discord.gg/electronjs) that should be willing to point you in the right direction. For your question, I'd recommend the Discord - we have many active help channels and mentors, as well as fellow devs, who can help you out.

--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -26,7 +26,4 @@ It is important that other working groups have autonomy and agency to fulfill th
 
 The AWG is open to welcoming new members. Please note that as a prerequisite, interested parties must manage a substantial investment in the project, including supporting teams that contain regular Electron contributors
 
-
-
 ## Meeting Schedule
-

--- a/wg-administrative/initiatives/OpenJS.md
+++ b/wg-administrative/initiatives/OpenJS.md
@@ -33,6 +33,6 @@ We will strive for unanimous consensus, and failing that will look for majority 
 - [@cruzerld](https://github.com/cruzerld)
 - [@felixrieseberg](https://github.com/felixrieseberg)
 - [@groundwater](https://github.com/groundwater)
-- [@jkleinsc](https://github.com/jkleinsc) [initial chair]
+- [@jkleinsc](https://github.com/jkleinsc) (initial chair)
 - [@lee-dohm](https://github.com/lee-dohm)
 - [@nornagon](https://github.com/nornagon)

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -3,14 +3,17 @@
 The following are a set of guidelines for building Electron APIs. This document is maintained by the [API Working Group](./).
 
 ## Questions to ask for every API change
+
 These questions are intended to prompt reflection and bring up things that the API author may not have considered when designing the API.
 
 ### Does this API change alter any existing behavior? In what way?
+
 API changes which alter existing behavior can cause apps to break unexpectedly when they upgrade to a newer version of Electron. Even seemingly minor behavior changes can often have unintended consequences. If possible, changes to Electron’s APIs should not alter behavior of existing code.
 
 If the behavior must change to support the feature, the change should be listed in [the breaking changes document](https://github.com/electron/electron/blob/main/docs/breaking-changes.md). Additionally, consider whether the change can be introduced in a way which permits a deprecation cycle, for instance introducing the new API under a new name and deprecating the old name while keeping the behavior unchanged for apps using the API under the old name.
 
 ### How will this API be extended in the future?
+
 What additional changes can you imagine being made to this API in the future? Are there any features that are not in the first version of a change you’re making that you would like to include in the future?
 
 Take some time to anticipate how the API might evolve, and design the API in such a way that reasonably-anticipated changes can be made in future without breaking backwards compatibility.
@@ -30,17 +33,21 @@ function whatever(opts: { a: string, b?: boolean }) { /* ... */ }
 See https://w3ctag.github.io/design-principles/#prefer-dict-to-bool for more details.
 
 ### What underlying Chromium or OS features does this API rely on?
+
 If the API you’re changing relies on underlying features provided by Chromium or by the operating system, how stable are those underlying features? How might those underlying features change in the future?
 
 Can we design this API to insulate users from such changes? i.e, if the underlying API changes, can we keep the API we expose to users unchanged—such that they can upgrade Electron without having to change their code?
 
 ### Can this API be implemented on all the platforms that Electron supports?
+
 If this API interacts with the underlying platform (Windows, macOS or Linux), consider whether the API makes sense on all platforms. It’s OK for an API to be platform-specific, but if the underlying feature exists on more than one platform, the API should be designed in such a way that it can behave uniformly on all supported platforms if possible. If you haven’t already implemented the API on other platforms, research how the API could be implemented on other platforms and take care to ensure that the API design works for all of them.
 
 ### Can this API be implemented as a native Node addon?
+
 It’s tempting to add functionality that you need to Electron, in order to avoid having to deal with compiling native modules. But not every feature belongs in the core of Electron. Consider whether the functionality you’re trying to achieve might be better off as a native Node addon.
 
 ### Should this API be asynchronous?
+
 If the proposed API is synchronous, consider whether it would make sense for it to do any asynchronous work in the future. If so, should the API be asynchronous instead?
 
 It’s very difficult to change an API from being synchronous to being asynchronous—so consider from the outset whether it would make sense to define the API as asynchronous (i.e. returning a Promise), even if it doesn’t yet perform any asynchronous work.
@@ -52,11 +59,13 @@ However: don’t make an API asynchronous unless there’s a good reason to. Asy
 This guide is intended to steer Electron’s APIs towards consistency and ease of use. Often, there are many possible roughly-equivalent ways of implementing an API. This style guide is designed to help you choose between them.
 
 ### Prefer functions to classes
+
 Electron’s API surface should be mostly “flat”, that is, composed of functions which do not reference `this`.
 
 Classes should be used only when there is a persistent underlying resource that must be managed, such as a socket, a window, or some other handle.
 
 ### Prefer promises to callbacks
+
 If your code is asynchronous, it should return a Promise rather than taking a callback as a parameter.
 
 For example:
@@ -78,19 +87,23 @@ win.hookWindowMessage('MESSAGE', (args...) => {
 See https://w3ctag.github.io/design-principles/#promises.
 
 ### Manage resource lifetimes automatically
+
 Users should not have to reason about when a resource should be destroyed. destroy() methods are an anti-pattern. Leave resource management up to V8’s garbage collector, and use `gin_helper::Pinnable` to keep resources alive when needed.
 
 ### Preserve run-to-completion semantics
+
 Don’t modify data accessed via JavaScript APIs while a JavaScript event loop is running.
 
 See https://w3ctag.github.io/design-principles/#js-rtc for details.
 
 ### Prefer dictionary parameters over primitive parameters
+
 API methods should generally use dictionary parameters instead of a series of optional primitive parameters.
 
 See https://w3ctag.github.io/design-principles/#prefer-dict-to-bool for details.
 
 ### Make function parameters optional if possible
+
 If a parameter for an API function has a reasonable default value, make that parameter optional and specify the default value.
 
 Optional parameters should be named to make the default value obvious without being named negatively (see https://w3ctag.github.io/design-principles/#naming-optional-parameters).
@@ -98,11 +111,13 @@ Optional parameters should be named to make the default value obvious without be
 See https://w3ctag.github.io/design-principles/#optional-parameters for details.
 
 ### Cancel asynchronous operations using AbortSignal
+
 If an asynchronous function can be cancelled, allow authors to pass in an AbortSignal as part of an options dictionary.
 
 See https://w3ctag.github.io/design-principles/#aborting.
 
 ### Use strings for constants and enums
+
 If your API needs a constant, or a set of enumerated values, use string values.
 
 Strings are easier for developers to inspect, and in JavaScript engines there is no performance benefit from using integers instead of strings.
@@ -112,6 +127,7 @@ If you need to express a state which is a combination of properties, which might
 See https://w3ctag.github.io/design-principles/#string-constants.
 
 ### Use milliseconds for time measurement
+
 If you are designing an API that accepts a time measurement, express the time measurement in milliseconds.
 
 Even if seconds (or some other time unit) are more natural in the domain of an API, sticking with milliseconds ensures that APIs are interoperable with one another. This means that authors don’t need to convert values used in one API to be used in another API, or keep track of which time unit is needed where.

--- a/wg-api/design-spec-process.md
+++ b/wg-api/design-spec-process.md
@@ -3,6 +3,7 @@
 ## What Is This Used For?
 
 The API Working Group should function as a clear escalation path towards resolving differing perspectives for the following API changes:
+
 * A new API
 * An API removal with replacement
 * An API deprecation and removal with no replacement

--- a/wg-api/spec-documents/message-ports.md
+++ b/wg-api/spec-documents/message-ports.md
@@ -72,7 +72,7 @@ When this message is received in the main process, any `MessagePort` objects tra
 
 Similar to `WebContents.send`, but allows transferring transferable objects.
 
-> [name=Samuel Attard]
+> \[name=Samuel Attard]
 > I'm trying to figure out if there's a way for this to be non-breaking integrated into `.send` to avoid the confusion around two different ways to send IPC.  Can't see an easy way out there though.
 
 #### Class: ipcMain.MessageChannel extends EventEmitter
@@ -116,7 +116,7 @@ Emitted when the channel is closed.
 :warning: This event is not part of the Web Messaging API.
 ::::
 
-> [name=Samuel Attard]
+> \[name=Samuel Attard]
 > Is there a way to tell if a message port has been closed *after* the fact.  E.g. `port.isClosed` or something?  Otherwise I assume `postMessage` will throw if the port is closed and you try to send a message.
 
 ## Example usage of new API
@@ -126,7 +126,8 @@ Emitted when the channel is closed.
 In the following example, the main process creates a channel, and then sends each end of it to a different renderer. Subsequent communication over that channel is direct between the two renderers, without the involvement of the main process.
 
 *ui_renderer.js*
-```javascript=
+
+```javascript
 let workerConnection = null
 ipcRenderer.on('worker_connection', (e, {port}) => {
   workerConnection = port
@@ -142,7 +143,8 @@ function beginWork() {
 ```
 
 *worker_renderer.js*
-```javascript=
+
+```javascript
 ipcRenderer.on('register', (e, {port}) => {
   port.onmessage = handleOperation(port)
 })
@@ -158,7 +160,8 @@ const handleOperation = (port) => async ({operation, data}) => {
 ```
 
 *main.js*
-```javascript=
+
+```javascript
 const worker = new BrowserWindow({
   show: false,
   webPreferences: {nodeIntegration: true}
@@ -189,7 +192,7 @@ In Blink, `MessagePort` is a fairly thin wrapper around a Mojo pipe. Node's mess
 
 In our current IPC implementation we have a boolean flag for whether an IPC message is 'internal' or not, and we avoid exposing internal IPCs to users. Using the new channel messaging API, it would be possible to create an 'internal' channel over which such messages could be sent—in fact, we could create as many different channels as we liked. In particular, it would be useful to separate each different Electron API into its own channel, which would eliminate the possibility of namespace collision between APIs, and additionally provide a security feature: possession of the channel port implies permission to use the API, and without a port it would be impossible to use that feature.
 
-> [name=Samuel Attard]
+> \[name=Samuel Attard]
 > This design would be that *all* APIs would by definition become async in the renderer if they required IPC to back them as I'm assuming we wouldn't make a `postMessageSync` API.  This means all usages of `sendSync` or `invokeSync` either get stuck on the old API or have to have breaking API changes.  It sounds like a lot of our internal impls wouldn't be able to use this because of this restriction.
 
 ### 'close' event

--- a/wg-api/spec-documents/scroll-view.md
+++ b/wg-api/spec-documents/scroll-view.md
@@ -5,7 +5,8 @@
 This spec proposes to add an experimental native ScrollView component to Electron.
 
 ## Platforms
-* macOS 
+
+* macOS
 * Windows
 * Linux
 
@@ -45,13 +46,12 @@ scroll.setContentSize({ width: 2000, height: 500 })
 win.addChildView(scroll)
 ```
 
-
 ## API Design
 
-- `View` - The base class for native UI elements.
-- `ImageView` - The native UI element that displays image.
-- `WebContentsView` - The native UI element that displays the content of `WebContents`.
-- `ScrollView` - The native UI element that make any View scrollable.
+* `View` - The base class for native UI elements.
+* `ImageView` - The native UI element that displays image.
+* `WebContentsView` - The native UI element that displays the content of `WebContents`.
+* `ScrollView` - The native UI element that make any View scrollable.
 
 ## View
 
@@ -115,8 +115,7 @@ with `addChildView`.
 
 Emitted when the view's size has been changed.
 
- 
-## BaseWindow 
+## BaseWindow
 
 ### New instance methods
 
@@ -132,7 +131,6 @@ Emitted when the view's size has been changed.
 
 Returns `View[]` - an array of all Views that have been attached
 with `addChildView`.
-
 
 ## ScrollView
 
@@ -172,6 +170,7 @@ Returns the `size` of the contents.
 * `mode` string - Can be `disabled`, `enabled-but-hidden`, `enabled`. Default is `enabled`.
 
 Controls how the horizontal scroll bar appears and functions.
+
 * `disabled` - The scrollbar is hidden.
 * `enabled-but-hidden` - The scrollbar is hidden whether or not the contents are larger than the viewport, but the pane will respond to scroll events. _Linux_  _Windows_
 *`enabled` - The scrollbar will be visible if the contents are larger than the viewport.
@@ -195,10 +194,11 @@ Returns `string` - vertical scrollbar mode.
 * `elasticity` string - Can be `automatic`, `none`, `allowed`. Default is `automatic`.
 
 The scroll view’s horizontal scrolling elasticity mode.
-A scroll view can scroll its contents past its bounds to achieve an elastic effect. 
+A scroll view can scroll its contents past its bounds to achieve an elastic effect.
 When set to `automatic`, scrolling the horizontal axis beyond its document
 bounds only occurs if the document width is greater than the view width,
 or the vertical scroller is hidden and the horizontal scroller is visible.
+
 * `automatic` - Automatically determine whether to allow elasticity on this axis.
 * `none` - Disallow scrolling beyond document bounds on this axis.
 * `allowed` - Allow content to be scrolled past its bounds on this axis in an elastic fashion.
@@ -259,8 +259,8 @@ Emitted at the end of user-initiated scrolling.
 
 ## Rollout Plan
 
-- duplicate the BrowserView API (setAutoResize, setBounds etc.) into View API; targeting Electron v21
-- add the documentation to [Views API (Part 1)](views-api-1-content-view.md); targeting Electron v21
-- adjust BaseWindow API to support the hierarchy of views (WebContentsViews); targeting Electron v21
-- add the ScrollView API (as experimental); targeting Electron v22
-- optimization the ScrollView with WebContentsViews for performance; targeting Electron v22
+* duplicate the BrowserView API (setAutoResize, setBounds etc.) into View API; targeting Electron v21
+* add the documentation to [Views API (Part 1)](views-api-1-content-view.md); targeting Electron v21
+* adjust BaseWindow API to support the hierarchy of views (WebContentsViews); targeting Electron v21
+* add the ScrollView API (as experimental); targeting Electron v22
+* optimization the ScrollView with WebContentsViews for performance; targeting Electron v22

--- a/wg-api/spec-documents/shell-openitem.md
+++ b/wg-api/spec-documents/shell-openitem.md
@@ -10,7 +10,7 @@
 
 ## Impetus
 
-At the moment, the return value of `shell.openItem(item)` arguably does not accurately reflect the success of the underlying operation being performed. 
+At the moment, the return value of `shell.openItem(item)` arguably does not accurately reflect the success of the underlying operation being performed.
 
 For example, on Linux, `true` can be returned when the file being passed as `item` doesn't exist, since it effectively returns the success of spawning `xdg-open` and not the exit code of `xdg-open` itself.
 
@@ -20,7 +20,7 @@ This new design will resolve ambiguities and allow users to more accurately unde
 
 The new method will adhere to the following semantics:
 
-```
+```markdown
 ### `shell.openPath(path)`
 
 * `path` String

--- a/wg-api/spec-documents/wc-print-sync.md
+++ b/wg-api/spec-documents/wc-print-sync.md
@@ -19,14 +19,13 @@ All.
 
 The following parameter changes will be made:
 
-
-```
+```markdown
 * `marginsType` Integer (optional) - Specifies the type of margins to use. Uses 0 for	default margin, 1 for no margin, and 2 for minimum margin.
 ```
-  
+
 will become
 
-```
+```markdown
 * `margins` Object (optional)
     * `marginType` String (optional) - Can be `default`, `none`, `printableArea`, or `custom`. If `custom` is chosen, you will also need to specify `top`, `bottom`, `left`, and `right`.
     * `top` Number (optional) - The top margin of the printed web page, in pixels.

--- a/wg-community-safety/new-reports-rotation.md
+++ b/wg-community-safety/new-reports-rotation.md
@@ -1,4 +1,5 @@
 # Community & Safety WG
+
 Rotation list for ensuring new reports get handled in a timely manner. Any report that comes in should be documented and a decision on next steps should be made within 24 hours. Each rotation will last 2 weeks so that they're synced with our WG meetings.
 
 | Dates | Point Person |

--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -20,7 +20,6 @@ Oversees the projects that make Electron app development easier.
 | <img src="https://github.com/georgexu99.png" width=100 alt="@georgexu99">  | George Xu [@georgexu99](https://github.com/georgexu99) | Member | PT (San Francisco) |
 | <img src="https://github.com/caoxiemeihao.png" width=100 alt="@caoxiemeihao">  | caoxiemeihao  [@caoxiemeihao](https://github.com/caoxiemeihao) | Member | BJT (Hangzhou) |
 
-
 ## Areas of Responsibility
 
 These projects are sorted alphabetically, their order does not reflect that any of them are "better" or "more important" than others.

--- a/wg-ecosystem/emails/request-for-link-on-site.md
+++ b/wg-ecosystem/emails/request-for-link-on-site.md
@@ -1,6 +1,6 @@
-Hi $REQUESTER,
+Hi {{REQUESTER}},
 
-I'm $NAME, [the current chair | a member] of Electron’s Website working group. Thank you for your email and thank you for your interest in supporting Electron!
+I'm {{NAME}}, {{the current chair | a member}} of Electron’s Website working group. Thank you for your email and thank you for your interest in supporting Electron!
 
 The logos displayed under "Built on Electron" are from our App Feedback Program members. This is a program for companies using Electron for their apps where they can give early feedback on testing betas of our major versions. This helps us prioritize the work that makes the greatest impact for them. If this interests you, please check out this page with more information on how to join: [Electron App Feedback Program](https://electronjs.org/blog/app-feedback-program).
 
@@ -9,4 +9,4 @@ All the applications on the Electron site come from the [Electron apps repositor
 If you have any more questions, please let me know and I'd be happy to answer them.
 
 Best,
-$NAME
+{{NAME}}

--- a/wg-infra/policy/access/npm.md
+++ b/wg-infra/policy/access/npm.md
@@ -1,6 +1,6 @@
 # NPM
 
-> ⚠️ This document currently described an ideal reality, not what is currently configured.  It will either be updated or implemented at some point in the future ⚠️ 
+> ⚠️ This document currently described an ideal reality, not what is currently configured.  It will either be updated or implemented at some point in the future ⚠️
 
 ## Access to the "electron" Organization on NPM
 

--- a/wg-infra/policy/leaving-governance.md
+++ b/wg-infra/policy/leaving-governance.md
@@ -7,9 +7,9 @@ This documents the process of leaving Electron Governance. A contributor is no l
 1. A governance member (Typically the WG Chair) update README file in [governance](https://github.com/electron/governance) for the WG the member is leaving.
 
 2. A governance member (Typically the WG Chair) submits a PR in [.permissions repo](https://github.com/electron/.permissions/).
-  * Merging this PR will automatically remove the contributor from:
-    * The WG's team on GitHub
-    * The WG's user group on Slack
+    * Merging this PR will automatically remove the contributor from:
+      * The WG's team on GitHub
+      * The WG's user group on Slack
 
 3. Reset the former member's Slack account email to a personal email.
 
@@ -21,7 +21,7 @@ This documents the process of leaving Electron Governance. A contributor is no l
 5. Message in `#access-requests` that the contributor has left Electron Governance.
 
 6. Disable the former member's GSuite account
-  * The account needs to be manually disabled, and 30 days later will be deleted.
-    * See [details on GSuite permissions](./access/gsuite.md).
-  
+    * The account needs to be manually disabled, and 30 days later will be deleted.
+      * See [details on GSuite permissions](./access/gsuite.md).
+
 7. Remove the former member from the [Electron organization](https://github.com/electron/) on GitHub.

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -1,7 +1,9 @@
 # Outreach WG
+
 Grows the Electron community
 
 ## Membership
+
 | Avatar | Name | Role | Time Zone |
 | ------ | ---- | ---- | --------- |
 | <img src="https://github.com/erickzhao.png" width=100 alt="@erickzhao">  | Erick Zhao [@erickzhao](https://github.com/erickzhao) | **Chair** | PT (Vancouver) |
@@ -24,20 +26,21 @@ Anyone interested in supporting the Electron community is invited to consider jo
 
 Being an active member of this working group requires that you actively participate in Electron's outreach efforts. Unlike other working groups, our mandate is broad and the ways in which you could support the Electron community are manyfold. With that in mind, membership requirements are equally roomy:
 
- * We expect members to regularly attend working group meetings
- * We expect members to actively devote time or other resources to outreach work on an ongoing basis
+* We expect members to regularly attend working group meetings
+* We expect members to actively devote time or other resources to outreach work on an ongoing basis
 
 Examples for work include writing or improving onboarding documentation, meeting and communicating with companies building apps on top of Electron, organizing conferences or meetups, or answering developer questions on social media. Helping developers building apps with Electron and community members interested in contributing to Electron can take on countless forms.
 
 ## Areas of Responsibility
 
-- Onboarding for new members
-- Reaching out to companies
-- Developer Evangelism / Developer Relations / Developer Advocate
-- Reaching out to Electron communities
-- Electron meetup events
+* Onboarding for new members
+* Reaching out to companies
+* Developer Evangelism / Developer Relations / Developer Advocate
+* Reaching out to Electron communities
+* Electron meetup events
 
 ## Meeting Schedule
-- **Sync Meeting** 60 min meeting every other Monday @ [18:00 UTC](https://duckduckgo.com/?q=18%3A00+UTC&ia=answer)
+
+* **Sync Meeting** 60 min meeting every other Monday @ [18:00 UTC](https://duckduckgo.com/?q=18%3A00+UTC&ia=answer)
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes).

--- a/wg-releases/feature-backport-requests.md
+++ b/wg-releases/feature-backport-requests.md
@@ -3,15 +3,22 @@
 Backporting non-breaking features to supported versions requires the approval of the Releases Working Group. Any feature PR that is targeting branch(es) other than `main` should be labeled with a `backport/requested 🗳` label.
 
 The approval process works as follows:
+
 1. By requesting backport of a feature, the submitter of the PR is assuming responsibility for this feature on the requested branches.
-  * If a backport PR causes any breakage, it may be removed if the PR submitter does not fix the breakage.
+
+    * If a backport PR causes any breakage, it may be removed if the PR submitter does not fix the breakage.
+
 2. All issues labeled as `backport/requested 🗳` will be reviewed during the Releases Working Group weekly meeting.
-  * Alternatively, the Releases Working Group may vote for issues asynchronously for requests that need a quicker response.
+
+    * Alternatively, the Releases Working Group may vote for issues asynchronously for requests that need a quicker response.
+
 3. Backport requests require that at least 3 working group members from at least 2 different companies approve the request.
-  * If the submitter of the request is a member of the Release working group they may be one of the 3 approvers.
-  * If at least 3 working group members have approved the request and there are no objections from other members, the request will be immediately approved once 3 members have approved.
-  * If there is not unanimous approval of the feature, a majority of the Working Group will be required to approve the request.
-  * Due to the distributed nature of the Releases WG, a backport request that doesn't have consensus may take longer to be approved or rejected until all available members can weigh in.
+
+    * If the submitter of the request is a member of the Release working group they may be one of the 3 approvers.
+    * If at least 3 working group members have approved the request and there are no objections from other members, the request will be immediately approved once 3 members have approved.
+    * If there is not unanimous approval of the feature, a majority of the Working Group will be required to approve the request.
+    * Due to the distributed nature of the Releases WG, a backport request that doesn't have consensus may take longer to be approved or rejected until all available members can weigh in.
+
 4. Once a backport request has been decided upon the PR will be labeled appropriately with either a `backport/approved ✅` or `backport/declined ❌` label.
 
 Please note that during our quiet period during our [Final Beta Release](./major-release-process.md#final-beta-release), we will not accept feature backports to the major release line in beta.

--- a/wg-releases/major-release-process.md
+++ b/wg-releases/major-release-process.md
@@ -31,12 +31,12 @@ We need to ensure the following have owners and have been completed:
 * [Spectron](https://github.com/electron-userland/spectron) update - a version of Spectron should be published compatible with the new stable release
 * [Chromedriver](https://github.com/electron/chromedriver) update - a version of Chromedriver should be published compatible with the version of Chromium being shipped in the new stable version
 * Release notes
-    * Update stable version release notes with copyedited notes
-    * Ensure the following:
-        * Correct spelling, grammar, capitalization, etc.
-        * Items are categorized and organized properly, e.g., in Fixes or Other Changes
-        * Notes include the items merged after the last beta release
-    * Example: [v6.0.0 release notes](https://github.com/electron/electron/releases/tag/v6.0.0)
+  * Update stable version release notes with copyedited notes
+  * Ensure the following:
+    * Correct spelling, grammar, capitalization, etc.
+    * Items are categorized and organized properly, e.g., in Fixes or Other Changes
+    * Notes include the items merged after the last beta release
+  * Example: [v6.0.0 release notes](https://github.com/electron/electron/releases/tag/v6.0.0)
 
 ## Stable Release Promotion
 

--- a/wg-releases/release-captain-overview.md
+++ b/wg-releases/release-captain-overview.md
@@ -19,37 +19,43 @@ If you're not able to be the Release Captain during a specific period, or need o
 ## Responsibilites
 
 ### Ongoing (Week 1-8)
+
 * Review the current pre-release branch [project board][] for new items
 * Ensure that all items that block stable release have assigned members
-* Post a "go/no go" in the Releases Slack channel, to cancel a meeting if the [meeting agenda] is empty
-* Work through the [meeting agenda] to address action items
-    * Lead backport request voting process
-    * Assign a person to handle backports
-    * Address Questions/Comments/Ideas
+* Post a "go/no go" in the Releases Slack channel, to cancel a meeting if the [meeting agenda][] is empty
+* Work through the [meeting agenda][] to address action items
+  * Lead backport request voting process
+  * Assign a person to handle backports
+  * Address Questions/Comments/Ideas
 
 ### Start of Shift (Week 1)
+
 * Clone the [project board][] (select "Draft issues will be copied if selected" checkmark)
-    * ask an admin to make the board public
+  * ask an admin to make the board public
 * Update all items in the "beta prep" and "stable prep" columns
-    * This includes updating due dates, and adding any new items
+  * This includes updating due dates, and adding any new items
 * Make sure that the Releases WG Google Calendar is up to date with Stable & Beta dates
 
 ### Beta Prep (Week 3-4)
+
 * At the Releases WG meeting, go through the [project board][] and ensure all beta prep items have owners
 * Review new minor/feat PRs for any needed documentation updates
 * Review Chromium and Electron release notes for any upcoming deprecations (OS, API, etc)
-    * Check `BUILD.gn` in Chromium for details as well
+  * Check `BUILD.gn` in Chromium for details as well
 
 ### Beta Release (Week 4)
+
 * Ensure the beta is released on time
-    * In #bot-sudowoodo, go through the workflow to release the beta
-    * If you are not a releaser, make sure that a releaser is assigned
+  * In #bot-sudowoodo, go through the workflow to release the beta
+  * If you are not a releaser, make sure that a releaser is assigned
 
 ### Stable Prep (Week 7)
+
 * At the Releases WG meeting, go through the [project board][] and ensure all stable prep items have owners
 * Follow up with owners as the due dates approach, to make sure they're completed.
 
 ### Stable Release (Week 8)
+
 * Ensure the stable release is released on time
 * Perform a hand-off with the next Release Captain
 * Move any open or important items to the new pre-release branch [project board][].
@@ -57,7 +63,6 @@ If you're not able to be the Release Captain during a specific period, or need o
 ### Questions?
 
 If you have any questions, post in the Releases WG channel! While the Release Captain leads the release, they should never have to do a release alone - it's the responsibility of the entire working group. Always ask questions or ask for help if you need it.
-
 
 <!-- Link labels -->
 

--- a/wg-releases/sudowoodo.md
+++ b/wg-releases/sudowoodo.md
@@ -19,31 +19,34 @@ In order to trigger a new release:
 Sometimes Sudowoodo hits roadblocks and can't complete the release on its own. In nearly all cases, these roadblocks fall into one of a small number of categories.
 
 1. CircleCI timeouts
-  * **Symptoms**
-    * Sudowoodo fails due to "Build waiter failed"
-    * Check the build that it failed to wait for and see whether it was a command time out
-  * **How to fix**
-    * This happens sometimes as a result of failures of CircleCI infrastructure that cause builds to be rerun within their containers.
-    * Sudowoodo has built-in resilience to this.
-    * Should this occur, the release process can be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`.
+
+    * **Symptoms**
+      * Sudowoodo fails due to "Build waiter failed"
+      * Check the build that it failed to wait for and see whether it was a command time out
+    * **How to fix**
+      * This happens sometimes as a result of failures of CircleCI infrastructure that cause builds to be rerun within their containers.
+      * Sudowoodo has built-in resilience to this.
+      * Should this occur, the release process can be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`.
 
 2. GitHub Asset Upload Failure
-  * **Symptoms**
-    * Sudowoodo fails due to "Build waiter failed"
-    * Check the build that it failed to wait for and see whether it failed during "upload to github" with `HTTP Error 422` "Unprocessable Entity".
-  * **How to fix**
-    * Owing to a long-standing bug in GitHub's asset upload code, assets can become corrupted such that the assets fail to upload but exist as strange ghost assets, such that they cannot be deleted or re-uploaded.
-      * These ghost assets can be deleted from the UI: you can go to the draft release, delete the ghost assets (marked with a red question mark) and then re-run just the single build that failed to upload.
-      * The release process can then be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`
+
+    * **Symptoms**
+      * Sudowoodo fails due to "Build waiter failed"
+      * Check the build that it failed to wait for and see whether it failed during "upload to github" with `HTTP Error 422` "Unprocessable Entity".
+    * **How to fix**
+      * Owing to a long-standing bug in GitHub's asset upload code, assets can become corrupted such that the assets fail to upload but exist as strange ghost assets, such that they cannot be deleted or re-uploaded.
+        * These ghost assets can be deleted from the UI: you can go to the draft release, delete the ghost assets (marked with a red question mark) and then re-run just the single build that failed to upload.
+        * The release process can then be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`
 
 3. Sudowoodo fails after all builds have been completed
-  * **Symptoms**
-    * Sudowoodo fails and the logs in Slack clearly show "Build Completed"
-    * Check the logs in Papertrail to determine the actual cause of failure if it is not clear from the logs visible in Slack
-  * **How to fix**
-    * This might be because of a failure in later scripts
-    * Should this occur, the release process can be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`.
-    * Do not run `/blasting-off-again` blindly in this scenario; instead check the papertrail logs accessible through Heroku and do not continue until you know what went wrong.
-      * If you are unsure please ping `@releases-wg` for debugging assistance.
-  * In some of these cases Sudowoodo itself will wait and ask you if you want to retry a certain release step.
-    * For example, the `publish to npm` step is infinitely retryable through a slack button.
+
+    * **Symptoms**
+      * Sudowoodo fails and the logs in Slack clearly show "Build Completed"
+      * Check the logs in Papertrail to determine the actual cause of failure if it is not clear from the logs visible in Slack
+    * **How to fix**
+      * This might be because of a failure in later scripts
+      * Should this occur, the release process can be continued by invoking `/blasting-off-again {COMMIT_HASH}` as a backslash command in `#bot-releases`.
+      * Do not run `/blasting-off-again` blindly in this scenario; instead check the papertrail logs accessible through Heroku and do not continue until you know what went wrong.
+        * If you are unsure please ping `@releases-wg` for debugging assistance.
+    * In some of these cases Sudowoodo itself will wait and ask you if you want to retry a certain release step.
+      * For example, the `publish to npm` step is infinitely retryable through a slack button.

--- a/wg-security/README.md
+++ b/wg-security/README.md
@@ -31,7 +31,6 @@ incidents, and oversees rollout of fixes.
   * Security review of parts of the codebase
   * Security sign-off on IPC and certain API related changes
 
-
 ## Associated Repositories
 
 All repositories in the `electron` organization along with exclusive access
@@ -43,6 +42,6 @@ See [Membership and Notifications](membership-and-notifications.md)
 
 ## Meeting Schedule
 
-- **Sync Meeting** 1hr Weekly @ Wednesday 9:30AM PT
+* **Sync Meeting** 1hr Weekly @ Wednesday 9:30AM PT
 
 Meeting notes may be viewed in [meeting-notes](meeting-notes) as they become available.

--- a/wg-security/membership-and-notifications.md
+++ b/wg-security/membership-and-notifications.md
@@ -8,7 +8,7 @@ People who want to join the Security WG should apply by notifying the WG, which 
 
 When voting, members should consider: has the person shown a history of Electron maintenance that indicates they could contribute to the fixing of security issues? For example, do they have a history of commits to Electron? Have they worked with other maintainers in a constructive way?
 
-Based on that criteria, the WG encourages people whose applications were declined to continue collaborating with other maintainers, to continue landing PRs, to participate in other Working Groups, and to re-apply in the future. 
+Based on that criteria, the WG encourages people whose applications were declined to continue collaborating with other maintainers, to continue landing PRs, to participate in other Working Groups, and to re-apply in the future.
 
 ## Notifications
 

--- a/wg-upgrades/README.md
+++ b/wg-upgrades/README.md
@@ -40,21 +40,22 @@ Meeting notes may be viewed in [meeting-notes](meeting-notes).
 ## Joining the Upgrades WG
 
 In order to become formal members of the WG, prospective members must:
+
 1. be actively contributing to the work of the Upgrades WG, and
 2. be approved by a 2/3rds majority of current WG members (rounded up).
     1. The prospective member shall leave the meeting during the deliberation and vote.
     2. The meeting notes shall contain only the outcome of the vote (approved/not approved), not the individual votes.
     3. Members not able to attend the meeting at which the vote occurs may submit their vote to the Chair prior to the meeting.
-    
+
 If you're interested in joining the Upgrades Working Group, reach out to an [existing member](#membership) and ask to be invited to the regular meeting and as a guest to the #wg-upgrades channel in Slack.
 
 ### Actively contributing
 
 "Actively contributing" doesn't necessarily mean writing code, and it doesn't mean you have to be full-time on Electron Upgrades. It does mean that you should be in regular communication with the Upgrades WG (including attending meetings), and it does mean that you should be materially contributing to the project in some way. Some examples of actively contributing:
 
-- You maintain a piece of code that integrates with Chromium (possibly including some patches), and it occasionally breaks during major Chromium upgrades. You don't write code every week, but you're available in the Slack channel to field questions about that component.
-- You communicate regularly with the team maintaining one of Electron's dependencies, and help to coordinate releases and connect people on those teams to Electron. You don't write any code in Electron, but you help out reviewing the occasional PR.
-- You help triage bugs reported on Electron's issue tracker related to Electron's dependencies. 
+* You maintain a piece of code that integrates with Chromium (possibly including some patches), and it occasionally breaks during major Chromium upgrades. You don't write code every week, but you're available in the Slack channel to field questions about that component.
+* You communicate regularly with the team maintaining one of Electron's dependencies, and help to coordinate releases and connect people on those teams to Electron. You don't write any code in Electron, but you help out reviewing the occasional PR.
+* You help triage bugs reported on Electron's issue tracker related to Electron's dependencies.
 
 This is not an exhaustive list of ways you could be involved in the Upgrades WG. If you're not sure whether the Upgrades-related work you're doing counts as "actively contributing", reach out to a [member](#membership) and ask. 🙂
 


### PR DESCRIPTION
Follow-up to #535 which removes the remaining rule deviations from the standard `markdownlint` config and makes the necessary changes for a clean lint run.

The majority of these changes have no visible impact, those that do mostly fall into a few categories:

* Properly nesting unordered lists under ordered lists (needs 4 space indent)
* Setting the language ID on code fence blocks (visible change is syntax highlighting kicks in)
* Standardizing on `{{ foo }}` for variable templating in playbooks and response templates
  * This style was already used most of the time, the other styles were `[[ foo ]]` and `[ foo ]`, which trip our custom `markdownlint` rule for no shortcut reference links - those styles are at risk of being rendered as links accidentally, and make it difficult to catch legitimate broken links