### PR TITLE
chore: update Admin WG policy and member

### DIFF
--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -12,7 +12,7 @@ The initial group members consist of management from Microsoft, and Slack whose 
 | Avatar | Name | Role | Time Zone |
 | -------------------------------------------|----------------------|----------------------------| -------- |
 | <img src="https://github.com/PlaineKevin.png" width=100 alt="@PlaineKevin">  | Kevin Nguyen [@PlaineKevin](https://github.com/PlaineKevin) | Chair | PT (Los Angeles) |
-| <img src="https://github.com/jkleinsc.png" width=100 alt="@nornagon">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | EST (Harrisburg) |
+| <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | EST (Harrisburg) |
 
 ## Areas of Responsibility
 

--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -4,7 +4,7 @@ The Administrative Working Group (AWG) oversees the entire governance and projec
 
 AWG members should consist of folks who manage a substantial investment in the project.
 To avoid the AWG becoming the _superpower_ group,
-members should not participate in other technical working groups.
+members should not chair other technical working groups.
 The initial group members consist of management from Microsoft, and Slack whose teams contain full-time Electron contributors.
 
 ## Membership
@@ -12,7 +12,7 @@ The initial group members consist of management from Microsoft, and Slack whose 
 | Avatar | Name | Role | Time Zone |
 | -------------------------------------------|----------------------|----------------------------| -------- |
 | <img src="https://github.com/PlaineKevin.png" width=100 alt="@PlaineKevin">  | Kevin Nguyen [@PlaineKevin](https://github.com/PlaineKevin) | Chair | PT (Los Angeles) |
-| <img src="https://github.com/groundwater.png" width=100 alt="@groundwater">  | Jacob Groundwater [@groundwater](https://github.com/groundwater) | Member | PT (San Francisco) |
+| <img src="https://github.com/jkleinsc.png" width=100 alt="@nornagon">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | EST (Harrisburg) |
 
 ## Areas of Responsibility
 


### PR DESCRIPTION
This PR updates the Microsoft representative for the Admin Working Group and also contains one key policy change:

* Admin WG members can participate in other working groups, but cannot chair those groups.

Due to this policy change this PR requires approval from all of the current working groups: @electron/wg-api @electron/wg-community-safety @electron/wg-ecosystem @electron/wg-infra @electron/wg-outreach @electron/wg-releases @electron/wg-security @electron/wg-upgrades