### PR TITLE
chore: add emeritus members to working groups

### DIFF
--- a/charter/README.md
+++ b/charter/README.md
@@ -143,4 +143,4 @@ For the safety and security of the project, all maintainers who have been offboa
 
 ### Emeritus Status
 
-When a former maintainer is offboarded, they will be automatically moved to Emeritus status within the governance repo. There is no minimum required period of servicing as a working group member for this status - any working group member who served for any length of time, but is no longer part of the working group, is eligible.
+When a former maintainer is offboarded, they will be automatically moved to Emeritus status within the governance repo. There is no minimum required period of serving as a working group member for this status - any working group member who served for any length of time, but is no longer part of the working group, is eligible.

--- a/charter/README.md
+++ b/charter/README.md
@@ -130,3 +130,17 @@ If a delegate Working Group is failing to meet its responsibilities, the AWG may
 
 > **Authors note:**
 > The current Electorate/AWG mix places almost all the power in the hands of a few large corporations at the outset. While not ideal to many, this was chosen because it represents the present status-quo, as of writing. The choice to delay defining an Electorate was made to _ensure_ it was not rushed, and that we have time to balance project stakeholders large and small.
+
+## Onboarding / Offboarding
+
+### Offboarding
+
+Occasionally, Electron maintainers will become inactive, or must step down from the project for personal or professional reasons. When this happens, it is important to reduce the risk to the project of compromised accounts with administrative permissions. This is not intended as a judgement on any individual member, simply a risk mitigation strategy for the project as a whole.
+
+If a maintainer no longer wishes to be a part of a working group, they should let the working group know via Slack or by submitting a PR removing themselves from the working group in governance. If a maintainer becomes inactive, the working group may choose to vote the member out via their own process - this process will be defined by each individual working group.
+
+For the safety and security of the project, all maintainers who have been offboarded from all working groups will be removed from GitHub member status and GSuite. They may also be moved to a multi-channel guest in the maintainer Slack.
+
+### Emeritus Status
+
+When a former maintainer is offboarded, they will be automatically moved to Emeritus status within the governance repo. There is no minimum required period of servicing as a working group member for this status - any working group member who served for any length of time, but is no longer part of the working group, is eligible.

--- a/wg-administrative/README.md
+++ b/wg-administrative/README.md
@@ -14,6 +14,20 @@ The initial group members consist of management from Microsoft, and Slack whose 
 | <img src="https://github.com/PlaineKevin.png" width=100 alt="@PlaineKevin">  | Kevin Nguyen [@PlaineKevin](https://github.com/PlaineKevin) | Chair | PT (Los Angeles) |
 | <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | EST (Harrisburg) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/groundwater.png" width=100 alt="@groundwater"> | Jacob Groundwater [@groundwater](https://github.com/groundwater) | Member | PT (San Francisco) |
+  | <img src="https://github.com/mgc.png" width=100 alt="@mgc">  | Matt Crocker [@mgc](https://github.com/mgc) | **Chair** | PT (San Francisco) |
+  | <img src="https://github.com/molant.png" width=100 alt="@molant">  | Antón Molleda [@molant](https://github.com/molant) | Member | PST (Seattle) |
+  | <img src="https://github.com/deanihansen.png" width=100 alt="@deanihansen">  | Deani Hansen [@deanihansen](https://github.com/deanihansen) | Member | PST (Vancouver) |
+  | <img src="https://github.com/felixrieseberg.png" width=100 alt="@felixrieseberg"> | Felix Rieseberg [@felixrieseberg](https://github.com/felixrieseberg) | Member | PT (San Francisco) |
+</details>
+
 ## Areas of Responsibility
 
 The AWG aims to ensure the collective health of the maintainers and working groups, while offering support as necessary through means that may not fall on any existing working group, such as a mechanism for escalation.

--- a/wg-api/README.md
+++ b/wg-api/README.md
@@ -47,6 +47,12 @@ In order to become formal members of the WG, prospective members must:
 
 If you're interested in joining the API Working Group, reach out to an [existing member](#membership) and ask to be invited to the regular meeting and as a guest to the #wg-api channel in Slack.
 
+## WG Removal Policy
+
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+
+This is done primarily to ensure that there are no open avenues of compromise for the project given that the API WG confers notable permissions.
+
 ### Actively contributing
 
 "Actively contributing" doesn't necessarily mean writing code. It does mean that you should be in regular communication with the API WG (including attending meetings), and it does mean that you should be materially contributing to the project in some way. If you're not sure whether the work you're doing counts as "materially contributing", reach out to a [member](#membership) and ask. 🙂

--- a/wg-community-safety/README.md
+++ b/wg-community-safety/README.md
@@ -11,6 +11,19 @@ Oversees removal/bans from community.
 | <img src="https://github.com/vertedinde.png" width=100 alt="@vertedinde">  | Keeley Hammond [@VerteDinde](https://github.com/vertedinde) | Member | PT (Portland) |
 | <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | ET (Harrisburg) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/groundwater.png" width=100 alt="@groundwater"> | Jacob Groundwater [@groundwater](https://github.com/groundwater) | Member | PT (San Francisco) |
+  | <img src="https://github.com/lee-dohm.png" width=100 alt="@lee-dohm"> | Lee Dohm [@lee-dohm](https://github.com/lee-dohm) | **Chair** | PT (Seattle) |
+  | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy">  | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
+  | <img src="https://github.com/tonyganch.png" width=100 alt="@tonyganch">  | Tony Ganch [@tonyganch](https://github.com/tonyganch) | Member | CET (Prague) |
+</details>
+
 ## Areas of Responsibility
 
 * Approval of adding and removing Slack Owners / Admins.

--- a/wg-ecosystem/README.md
+++ b/wg-ecosystem/README.md
@@ -20,6 +20,22 @@ Oversees the projects that make Electron app development easier.
 | <img src="https://github.com/caoxiemeihao.png" width=100 alt="@caoxiemeihao">  | caoxiemeihao  [@caoxiemeihao](https://github.com/caoxiemeihao) | Member | BJT (Hangzhou) |
 | <img src="https://github.com/erikian.png" width=100 alt="@erikian">  | Erik Moura  [@erikian](https://github.com/erikian) | Member | BRT (Francisco Beltrão) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/molant.png" width=100 alt="@molant"> | Antón Molleda [@molant](https://github.com/molant) | Chair | PT (Seattle) |
+  | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
+  | <img src="https://github.com/vhashimotoo.png" width=100 alt="@vhashimotoo"> | Vlad Hashimoto [@vhashimotoo](https://github.com/vhashimotoo) | Chair | CET (Germany, Frankfurt am Main) |
+  | <img src="https://github.com/bandantonio.png" width=100 alt="@bandantonio"> | Anton Zolotukhin [@bandantonio](https://github.com/bandantonio) | Observer (until December 2020) | EET (Kharkov) |
+  | <img src="https://github.com/shiftkey.png" width=100 alt="@shiftkey"> | Brendan Forster [@shiftkey](https://github.com/shiftkey) | Member | AT (Canada) |
+  | <img src="https://github.com/miniak.png" width=100 alt="@miniak"> | Milan Burda [@miniak](https://github.com/miniak) | Member | CET (Prague) |
+  | <img src="https://github.com/nitsakh.png" width=100 alt="@nitsakh"> | Nitish Sakhawalkar [@nitsakh](https://github.com/nitsakh) | Member | PT (San Francisco) |
+</details>
+
 ## Areas of Responsibility
 
 These projects are sorted alphabetically, their order does not reflect that any of them are "better" or "more important" than others.
@@ -49,6 +65,12 @@ These projects are sorted alphabetically, their order does not reflect that any 
   * Spectron
 
 ...and all other third party community based Electron tools.
+
+## WG Removal Policy
+
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+
+This is done primarily to ensure that there are no open avenues of compromise for the project given that the Ecosystem WG confers notable permissions.
 
 ## Associated Repositories
 

--- a/wg-outreach/README.md
+++ b/wg-outreach/README.md
@@ -19,6 +19,19 @@ It also manages Electron's presence at in-person and online developer spaces (e.
 | <img src="https://github.com/marshallofsound.png" width=100 alt="@marshallofsound">  | Samuel Attard [@MarshallOfSound](https://github.com/marshallofsound) | Member | PT (Vancouver) |
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PT (Portland) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
+  | <img src="https://github.com/erikmellum.png" width=100 alt="@erikmellum"> | Erik Mellum [@erikmellum](https://github.com/erikmellum) | Member | PT (Chico) |
+  | <img src="https://github.com/BinaryMuse.png" width=100 alt="@BinaryMuse"> | Michelle Tilley [@BinaryMuse](https://github.com/BinaryMuse) | Member | PT (San Francisco) |
+  | <img src="https://github.com/tonyganch.png" width=100 alt="@tonyganch"> | Tony Ganch [@tonyganch](https://github.com/tonyganch) | Member | CET (Prague) |
+</details>
+
 ## Membership Requirements
 
 ### Becoming a member
@@ -33,6 +46,12 @@ Being an active member of this working group requires that you actively particip
 * We expect members to actively devote time or other resources to outreach work on an ongoing basis
 
 Examples for work include writing or improving onboarding documentation, meeting and communicating with companies building apps on top of Electron, organizing conferences or meetups, or answering developer questions on social media. Helping developers building apps with Electron and community members interested in contributing to Electron can take on countless forms.
+
+## WG Removal Policy
+
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+
+This is done primarily to ensure that there are no open avenues of compromise for the project given that the Outreach WG confers notable permissions.
 
 ## Meeting Schedule
 

--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -19,6 +19,21 @@ Oversees all release branches, and tooling to support releases.
 | <img src="https://github.com/georgexu99.png" width=100 alt="@georgexu99">  | George Xu [@georgexu99](https://github.com/georgexu99) | Member | PT (Seattle) |
 | <img src="https://github.com/dsanders11.png" width=100 alt="@dsanders11">  | David Sanders [@dsanders11](https://github.com/dsanders11) | Member | PT (Santa Barbara) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/sofianguy.png" width=100 alt="@sofianguy"> | Sofia Nguy [@sofianguy](https://github.com/sofianguy) | Member | PT (San Francisco) |
+  | <img src="https://github.com/deermichel.png" width=100 alt="@deermichel"> | Micha Hanselmann [@deermichel](https://github.com/deermichel) | Member | CET (Prague) |
+  | <img src="https://github.com/amclegg.png" width=100 alt="@amclegg"> | Anna Clegg [@amclegg](https://github.com/amclegg) | Member | PT (San Francisco) |
+  | <img src="https://github.com/alexeykuzmin.png" width=100 alt="@alexeykuzmin"> | Alexey Kuzmin [@alexeykuzmin](https://github.com/alexeykuzmin) | Member | CET (Prague) |
+  | <img src="https://github.com/binarymuse.png" width=100 alt="@binarymuse"> | Michelle Tilley [@BinaryMuse](https://github.com/binarymuse) | Member | PT (San Francisco) |
+  | <img src="https://github.com/erickzhao.png" width=100 alt="@erickzhao"> | Erick Zhao [@erickzhao](https://github.com/erickzhao) | Observer | PT (San Francisco) |
+</details>
+
 ## Areas of Responsibility
 
 * Releasing Electron according to schedule

--- a/wg-security/README.md
+++ b/wg-security/README.md
@@ -39,6 +39,12 @@ to `electron/security`.
 
 See [Membership and Notifications](membership-and-notifications.md)
 
+## WG Removal Policy
+
+If a sitting member of the WG has not been active in a meaningful way for at least one month, the WG may vote to remove them from its set of sitting members.
+
+This is done primarily to ensure that there are no open avenues of compromise for the project given that the Security WG confers notable permissions.
+
 ## Meeting Schedule
 
 * **Sync Meeting** 1hr Weekly @ Wednesday 9:30AM PT

--- a/wg-upgrades/README.md
+++ b/wg-upgrades/README.md
@@ -15,6 +15,20 @@ Oversees upgrades of upstream dependencies; specifically Chromium and Node.
 | <img src="https://github.com/VerteDinde.png" width=100 alt="@VerteDinde">  | Keeley Hammond [@VerteDinde](https://github.com/VerteDinde) | Member | PST (Portland) |
 | <img src="https://github.com/jkleinsc.png" width=100 alt="@jkleinsc">  | John Kleinschmidt [@jkleinsc](https://github.com/jkleinsc) | Member | EST (Harrisburg) |
 
+## Emeritus Members
+
+<details>
+  <summary>Emeritus Members</summary>
+
+  | Avatar | Name | Role | Time Zone |
+  | -------------------------------------------|----------------------|----------------------------| -------- |
+  | <img src="https://github.com/alexeykuzmin.png" width=100 alt="@alexeykuzmin"> | Alexey Kuzmin [@alexeykuzmin](https://github.com/alexeykuzmin) | Member | CET (Prague) |
+  | <img src="https://github.com/brenca.png" width=100 alt="@brenca"> | Heilig Benedek [@brenca](https://github.com/brenca) | Member | CET (Budapest) |
+  | <img src="https://github.com/loc.png" width=100 alt="@loc"> | Andy Locascio [@loc](https://github.com/loc) | Member | PT (San Francisco) |
+  | <img src="https://github.com/ryzokuken.png" width=100 alt="@ryzokuken"> | Ujjwal Sharma [@ryzokuken](https://github.com/ryzokuken) | Member | ? |
+  | <img src="https://github.com/nitsakh.png" width=100 alt="@nitsakh"> | Nitish Sakhawalkar [@nitsakh](https://github.com/nitsakh) | Member | PT (San Francisco) |
+</details>
+
 ## Areas of Responsibility
 
 * Ensuring that Chromium and Node upgrades happen in a timely fashion


### PR DESCRIPTION
This PR follows up on several off boarding items discussed at the October Boston Electron Summit:

- Adds a status for emeritus, or former members of working groups.
- Adds a description for what qualifies a member for emeritus status
- Explicitly defines a process for removing inactive maintainers from working groups.

This PR does not define what an inactive member means - that definition should be determined individually by each working group, and added to individual working group READMEs.

_Note: The members listed here as emeritus were pulled from git and Slack history, and may not be a complete list. If you feel you've been added in error, or are not on the list and should be, please reach out or comment here. 🙏_