### PR TITLE
ci: update lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Setup Node.js
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+      uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
       with:
-        node-version: 18.x
+        node-version: 20.x
     - name: Create a Temporary package.json
       run: npm init --yes
     - name: Install @electron/lint-roller
@@ -32,8 +32,8 @@ jobs:
     - name: Run markdownlint
       run: npx electron-markdownlint "**/*.md"
     - name: Lint links
-      run: npx electron-lint-markdown-links --root . --ignore-path .markdownlintignore "**/*.md"
+      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore "**/*.md"
       if: ${{ always() }}
     - name: Check external links
-      run: npx electron-lint-markdown-links --root . --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
+      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
       if: ${{ github.event.inputs.fetch-external-links }}


### PR DESCRIPTION
Bumps versions to get things off EOL Node.js versions and preempts deprecation warnings. Also drops a no longer necessary option flag for `@electron/lint-roller`.