### PR TITLE
ci: fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,4 @@ jobs:
       if: ${{ always() }}
     - name: Check external links
       run: npx lint-roller-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
-      if: ${{ github.event.inputs.fetch-external-links }}
+      if: ${{ inputs.fetch-external-links }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,12 @@ jobs:
     - name: Create a Temporary package.json
       run: npm init --yes
     - name: Install @electron/lint-roller
-      run: npm install --save-dev @electron/lint-roller
+      run: npm install --save-dev @electron/lint-roller@^2.1.0
     - name: Run markdownlint
       run: npx electron-markdownlint "**/*.md"
     - name: Lint links
-      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore "**/*.md"
+      run: npx lint-roller-markdown-links --ignore-path .markdownlintignore "**/*.md"
       if: ${{ always() }}
     - name: Check external links
-      run: npx electron-lint-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
+      run: npx lint-roller-markdown-links --ignore-path .markdownlintignore --fetch-external-links "**/*.md"
       if: ${{ github.event.inputs.fetch-external-links }}


### PR DESCRIPTION
Fixing the breaking change from `@electron/lint-roller` v2, since this workflow wasn't pinning to a particular version.

Also fixes usage of the boolean input for fetch external links, it was previously always running since `github.event.inputs.fetch-external-links` converts the boolean to a string, but `inputs.fetch-external-links` does not.