### PR TITLE
docs: define practices for third-party extensible APIs

### DIFF
--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -156,11 +156,11 @@ protocol.registerSchemesAsPrivileged([
 ])
 
 // Good: third-party libraries can create, read, update, and delete items
-if (protocol.getRegisteredSchemes().includes(scheme => scheme.scheme === 'app')) {
-  protocol.unregisterScheme({ scheme: 'app' })
+if (protocol.getPrivilegedSchemes().includes(scheme => scheme.scheme === 'app')) {
+  protocol.unregisterSchemeAsPrivileged('app' )
 }
-protocol.registerScheme({ scheme: 'app', privileges: { standard: true } })
-protocol.updateScheme({ scheme: 'app', privileges: { secure: true } })
+protocol.registerSchemeAsPrivileged({ scheme: 'app', privileges: { standard: true } })
+protocol.updatePrivilegedScheme({ scheme: 'app', privileges: { secure: true } })
 ```
 
 ## Classes

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -32,6 +32,13 @@ function whatever(opts: { a: string, b?: boolean }) { /* ... */ }
 
 See https://w3ctag.github.io/design-principles/#prefer-dict-to-bool for more details.
 
+### Should the configured options be made extensible to third-party libraries?
+
+If an API accepts configuring options, should it provide the ability to append to rather than replace those options?
+Would third-party libraries require special attention to API usage to avoid clobbering configured options?
+
+See the [style guide for designing APIs when dealing with arrays.](#provide-createreadupdatedelete-options-when-dealing-with-arrays)
+
 ### What underlying Chromium or OS features does this API rely on?
 
 If the API you’re changing relies on underlying features provided by Chromium or by the operating system, how stable are those underlying features? How might those underlying features change in the future?
@@ -133,6 +140,26 @@ If you are designing an API that accepts a time measurement, express the time me
 Even if seconds (or some other time unit) are more natural in the domain of an API, sticking with milliseconds ensures that APIs are interoperable with one another. This means that authors don’t need to convert values used in one API to be used in another API, or keep track of which time unit is needed where.
 
 See https://w3ctag.github.io/design-principles/#milliseconds
+
+### Provide create/read/update/delete options when dealing with arrays
+
+If an API is designed to accept an array of items, consider providing methods of creating, reading, updating, and deleting items.
+
+In the case of third-party libraries, one might want to add a single item rather than replacing existings items.
+
+```js
+// Bad: third-party libraries can only replace registered schemes
+protocol.registerSchemesAsPrivileged([
+  { scheme: 'app', privileges: { standard: true } }
+])
+
+// Good: third-party libraries can create, read, update, and delete items
+if (protocol.getRegisteredSchemes().includes(scheme => scheme.scheme === 'app')) {
+  protocol.unregisterScheme({ scheme: 'app' })
+}
+protocol.registerScheme({ scheme: 'app', privileges: { standard: true } })
+protocol.updateScheme({ scheme: 'app', privileges: { secure: true } })
+```
 
 ## Classes
 

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -157,7 +157,7 @@ protocol.registerSchemesAsPrivileged([
 
 // Good: third-party libraries can create, read, update, and delete items
 if (protocol.getPrivilegedSchemes().includes(scheme => scheme.scheme === 'app')) {
-  protocol.unregisterSchemeAsPrivileged('app' )
+  protocol.unregisterSchemeAsPrivileged('app')
 }
 protocol.registerSchemeAsPrivileged({ scheme: 'app', privileges: { standard: true } })
 protocol.updatePrivilegedScheme({ scheme: 'app', privileges: { secure: true } })

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -32,7 +32,7 @@ function whatever(opts: { a: string, b?: boolean }) { /* ... */ }
 
 See https://w3ctag.github.io/design-principles/#prefer-dict-to-bool for more details.
 
-### How will third-party libraries interact with this API?
+### How will isolated components (e.g. third-party libraries) interact with this API?
 
 When designing an API, consider that an app might have custom code and third-party libraries that both interact with that API. Can the API be designed so that multiple callers don't interfere with each other?
 
@@ -147,7 +147,7 @@ See https://w3ctag.github.io/design-principles/#milliseconds
 
 If an API is designed to accept an array of items, consider providing methods of creating, reading, updating, and deleting items.
 
-In the case of third-party libraries, one might want to add a single item rather than replacing existings items.
+In the case of isolated components (e.g. third-party libraries), one might want to add a single item rather than replacing existings items.
 
 ```js
 // Bad: third-party libraries can only replace registered schemes

--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -32,10 +32,12 @@ function whatever(opts: { a: string, b?: boolean }) { /* ... */ }
 
 See https://w3ctag.github.io/design-principles/#prefer-dict-to-bool for more details.
 
-### Should the configured options be made extensible to third-party libraries?
+### How will third-party libraries interact with this API?
+
+When designing an API, consider that an app might have custom code and third-party libraries that both interact with that API. Can the API be designed so that multiple callers don't interfere with each other?
 
 If an API accepts configuring options, should it provide the ability to append to rather than replace those options?
-Would third-party libraries require special attention to API usage to avoid clobbering configured options?
+Can third-party libraries use the API without knowing what app-specific code is also using the API?
 
 See the [style guide for designing APIs when dealing with arrays.](#provide-createreadupdatedelete-options-when-dealing-with-arrays)
 


### PR DESCRIPTION
A few of Electron's existing APIs don't do a good job of supporting extensibility for third-party libraries. Let's try to define best practices to guide future API designs with third-party extensibility in mind.

### `protocol.registerSchemesAsPrivileged`

- Replaces all schemes without an option of appending
- Known issue for third-party libraries https://github.com/electron/electron/issues/40362
- Requires monkey patching to workaround ([see Sentry's example](https://github.com/electron/electron/issues/40362#issuecomment-2248468360))

### `session.setPreloads` / `session.getPreloads`

- Requires replacing all preloads rather than adding a single preload

```js
session.setPreloads([
  ...session.getPreloads(),
  path.join(__dirname, 'new-preload-script.js')
])
```