### PR TITLE
docs: add release captain task to copy issues to new board

### DIFF
--- a/wg-releases/release-captain-overview.md
+++ b/wg-releases/release-captain-overview.md
@@ -31,10 +31,12 @@ If you're not able to be the Release Captain during a specific period, or need o
 ### Start of Shift (Week 1)
 
 * Clone the [project board][] (select "Draft issues will be copied if selected" checkmark)
-  * ask an admin to make the board public
+  * Ask an admin to make the board public
 * Update all items in the "beta prep" and "stable prep" columns
   * This includes updating due dates, and adding any new items
 * Make sure that the Releases WG Google Calendar is up to date with Stable & Beta dates
+* Copy important issues from the previous two project boards to the new [project board][]
+  * Review unsorted issues from the (closed) [project board][] two releases prior to the new pre-release board
 
 ### Beta Prep (Week 3-4)
 


### PR DESCRIPTION
Reasoning:

- We closed the v35 project board and opened the v37 board without reviewing the remaining issues from the v35 board in the WG releases meeting.
  - A bunch of new issues were added within the last week. Those should be reviewed to make sure every issue is looked at.
- It's better to have the new release captain do this than the old one.
  - Once your release is out, you might not care about it as much anymore as the person whose release cycle just started.