### PR TITLE
docs: APIs should return null

### DIFF
--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -166,6 +166,11 @@ protocol.registerSchemeAsPrivileged({ scheme: 'app', privileges: { standard: tru
 protocol.updatePrivilegedScheme({ scheme: 'app', privileges: { secure: true } })
 ```
 
+### Return null when no result from lookup functions
+
+APIs that intend to find an object by an identifier should return `null` in the
+case that the instance is not found.
+
 ## Classes
 
 ### Use a class's name as the module name


### PR DESCRIPTION
Adding a style rule to return `null` in APIs where a lookup has no result.

Ref: https://github.com/electron/electron/pull/47850