### PR TITLE
chore: resolve dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,5 @@
     "@electron/lint-roller": "^3.3.0",
     "markdownlint-cli2": "^0.22.0"
   },
-  "resolutions": {
-    "glob@npm:~10.3.12": "npm:10.5.0"
-  },
   "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f"
 }

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
     "@electron/lint-roller": "^3.3.0",
     "markdownlint-cli2": "^0.22.0"
   },
+  "resolutions": {
+    "glob@npm:~10.3.12": "npm:10.5.0"
+  },
   "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,21 +478,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.13
+  resolution: "brace-expansion@npm:1.1.13"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+  version: 2.0.3
+  resolution: "brace-expansion@npm:2.0.3"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/468436c9b2fa6f9e64d0cff8784b21300677571a7196e258593e95e7c3db9973a80fbafdb0f01404d5d298a04dc666eae1fc3c9052e2edbb9f2510541deeddfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Safe-only sweep of open Dependabot security alerts. Only changes that stay within existing semver ranges (or same-major resolutions) were applied — anything requiring a major bump of a direct dep is flagged below and left untouched.

### Resolved

| Package | Strategy | Version change |
|---|---|---|
| `glob` | scoped resolution (`glob@npm:~10.3.12` → `npm:10.5.0`) | `10.3.16` → `10.5.0` |
| `brace-expansion` | `yarn up -R` (in-range refresh) | `1.1.12` → `1.1.13`, `2.0.2` → `2.0.3` |

The `glob` alert comes in via `@electron/lint-roller@2.4.0` → `markdownlint-cli@^0.40.0` → `glob@~10.3.12`. There is no newer `2.x` of `@electron/lint-roller` and `markdownlint-cli`'s `~10.3.12` range can't reach the patched `10.5.0`, so a scoped resolution (same major) is the minimal safe fix. Only the `~10.3.12` descriptor is overridden — the `7.x`/`8.x`/`9.x` copies of `glob` elsewhere in the tree are untouched.

### Flagged (not changed)

- **`@electron/lint-roller` `^2.1.0` → `^3.x`** — would remove the `markdownlint-cli@0.40.0` chain entirely (and pull `glob@^10.4.5` directly), but it's a major bump of the only direct dep so out of scope for a safe-only sweep. Worth doing as a follow-up, which would also let the `glob` resolution be dropped.
- **`markdown-it` (audit only, not an open Dependabot alert)** — `13.0.2` / `14.1.0` in tree, patched in `14.1.1`. The `13.x` copy is pinned by `@electron/lint-roller@2.4.0` (`^13.0.1`) and the `14.1.0` copy is exact-pinned by `markdownlint@0.34.0`; both clear with the `lint-roller` `3.x` bump above.

### Verification

- `yarn install --immutable` passes
- `yarn npm audit`: `glob` and `brace-expansion` advisories cleared; only `markdown-it` (moderate, not an open Dependabot alert) remains
