### PR TITLE
docs: add @nmggithub to wg-releases

### DIFF
--- a/wg-releases/README.md
+++ b/wg-releases/README.md
@@ -17,6 +17,7 @@ Oversees all release branches, and tooling to support releases.
 | <img src="https://github.com/dsanders11.png" width=100 alt="@dsanders11"> | David Sanders [@dsanders11](https://github.com/dsanders11) | Member | PT (Santa Barbara) |
 | <img src="https://github.com/nikwen.png" width=100 alt="@nikwen"> | Niklas Wenzel [@nikwen](https://github.com/nikwen) | Member | CET (Berlin) |
 | <img src="https://github.com/rf-figma.png" width=100 alt="@rf-figma"> | Ryan Fitzgerald [@rf-figma](https://github.com/rf-figma) | Member | PT (San Francisco) |
+| <img src="https://github.com/nmggithub.png" width=100 alt="@nmggithub"> | Noah Gregory [@nmggithub](https://github.com/nmggithub) | Member | ET (United States) |
 
 ## Emeritus Members
 


### PR DESCRIPTION
Approved during today's WG Releases meeting.

They asked to keep the city private, so we put `United States`.