### PR TITLE
docs: clarify event object usage in EventEmitter examples

### DIFF
--- a/wg-api/best-practices.md
+++ b/wg-api/best-practices.md
@@ -248,6 +248,22 @@ Additionally, due to lack of function overloading, JavaScript class constructors
 
 If the class generates events, it should inherit from `EventEmitter` and use its interface for emitting events.
 
+Any details related to the event should be included in an event object.
+
+```javascript
+// ❌ Separate details object in addition to event object
+webContents.on('will-navigate', (event, details) => {
+  event.preventDefault()
+  const { url, frame } = details
+})
+
+// ✅ Event object passed with detail properties
+webContents.on('will-navigate', (event) => {
+  event.preventDefault()
+  const { url, frame } = event
+})
+```
+
 ### Use instance properties for non-assignable objects
 
 If an API of the class returns a _non-assignable_ `Object`, and the returned objects always strictly equal each other, the API should be implemented as property.


### PR DESCRIPTION
I noticed we don't detail the pattern of including details on event objects. This was brought up in an API review for https://github.com/electron/electron/pull/51563#discussion_r3455401277